### PR TITLE
Changed an edge case used for external searches

### DIFF
--- a/src/TabBlazor/Components/Tables/Components/TheGridDataFactory.cs
+++ b/src/TabBlazor/Components/Tables/Components/TheGridDataFactory.cs
@@ -47,7 +47,7 @@ namespace TabBlazor.Components.Tables
 
                 else if ((state.TotalCount - 1) < state.PageSize * state.PageNumber)
                 {
-                    state.PageNumber = (int)Math.Floor((decimal)(state.TotalCount / state.PageSize)) - 1;
+                    state.PageNumber = (int)Math.Floor((decimal)(state.TotalCount / state.PageSize));
                 }
                 else if (moveToItem != null)
                 {


### PR DESCRIPTION
(int)Math.Floor((decimal)(state.TotalCount / state.PageSize)) - 1 would put the value at negative if TotalCount is less than PageSize.