### PR TITLE
Removing registered click event handler when it has occurred.

### DIFF
--- a/docs/Tabler.Docs/Components/Helpers/ClickOutside/Basic.razor
+++ b/docs/Tabler.Docs/Components/Helpers/ClickOutside/Basic.razor
@@ -3,7 +3,6 @@
     <div class="p-1 border">
         <h3>Here is some content</h3>
         Try to click outside
-
     </div>
 </ClickOutside>
 

--- a/docs/Tabler.Docs/Components/Helpers/ClickOutside/Basic.razor
+++ b/docs/Tabler.Docs/Components/Helpers/ClickOutside/Basic.razor
@@ -1,5 +1,5 @@
 ﻿
-<ClickOutside OnClickOutside="OutsideClicked">
+<ClickOutside OnClickOutside=@(()=>OutsideClicked("Basic")) Strategy="ClickOutside.RegisterStrategy.OnRender" Concurrence="ClickOutside.ConcurrenceStrategy.Many">
     <div class="p-1 border">
         <h3>Here is some content</h3>
         Try to click outside
@@ -7,6 +7,7 @@
     </div>
 </ClickOutside>
 
+<br/>
 
 @code {
     [Inject] private ToastService toastService { get; set; }
@@ -17,10 +18,9 @@
         containerSize = resizeObserverEntry.ContentRect;
     }
 
-    private async Task OutsideClicked()
+    private async Task OutsideClicked(string component)
     {
-        await toastService.RemoveAllAsync();
-        await toastService.AddToastAsync(new ToastModel { Title = @DateTime.Now.ToString("T"), Message = "You clicked outside container..." });
+        await toastService.AddToastAsync(new ToastModel { Title = @DateTime.Now.ToString("T"), Message = $"You clicked outside container {component}..." });
     }
 
 }

--- a/docs/Tabler.Docs/Components/Helpers/ClickOutside/ClickOutsideSamples.razor
+++ b/docs/Tabler.Docs/Components/Helpers/ClickOutside/ClickOutsideSamples.razor
@@ -3,6 +3,8 @@
 <Page>
     <DocsExample Title="Click outside" ComponentType="typeof(ClickOutside)">
         <p>Sends an event if user clicks outside of the container</p>
+        <p>Each ClickOutside component get an event when the user click outside of it.</p>
+
         <CodeSnippet ClassName="@typeof(Basic).ToString()" Title="Basic">
             <Example>
                 <Basic />
@@ -10,6 +12,11 @@
         </CodeSnippet>
 
 
+        <CodeSnippet ClassName="@typeof(Multiple).ToString()" Title="Multiple components recieving click outside">
+            <Example>
+                <Multiple />
+            </Example>
+        </CodeSnippet>
 
     </DocsExample>
 </Page>

--- a/docs/Tabler.Docs/Components/Helpers/ClickOutside/Multiple.razor
+++ b/docs/Tabler.Docs/Components/Helpers/ClickOutside/Multiple.razor
@@ -1,0 +1,41 @@
+﻿
+<ClickOutside OnClickOutside=@(()=>OutsideClicked("Content 1")) Strategy="ClickOutside.RegisterStrategy.OnClick" Concurrence="ClickOutside.ConcurrenceStrategy.One">
+    <div class="p-1 border" @onclick=@(()=>ShowRegistrationMessage("Content 1"))>
+        <h3>Content 1</h3>
+        I register for click events when you click on me. <br/>
+        Click me to register for click event from outside.<br/>
+        I will receive only the first click event outside.<br/>
+        Click me again to register for another click event from outside.
+    </div>
+</ClickOutside>
+
+<br />
+<ClickOutside OnClickOutside=@(()=>OutsideClicked("Content 2")) Strategy="ClickOutside.RegisterStrategy.OnRender" Concurrence="ClickOutside.ConcurrenceStrategy.Many">
+    <div class="p-1 border">
+        <h3>Content 2</h3>
+        I register for click events on render. <br/>
+        I will receive all click events from outside.
+    </div>
+</ClickOutside>
+
+@code {
+    [Inject] private ToastService toastService { get; set; }
+    private ContentRect containerSize;
+
+    private void ElementResized(ResizeObserverEntry resizeObserverEntry)
+    {
+        containerSize = resizeObserverEntry.ContentRect;
+    }
+
+    private async Task OutsideClicked(string component)
+    {
+        await toastService.AddToastAsync(new ToastModel { Title = @DateTime.Now.ToString("T"), Message = $"You clicked outside container {component}..." });
+    }
+
+    private async Task ShowRegistrationMessage(string component)
+    {
+        await toastService.AddToastAsync(new ToastModel { Title = @DateTime.Now.ToString("T"), Message = $"Register for click events outside of container {component}..." });
+
+    }
+
+}

--- a/docs/Tabler.Docs/Components/Helpers/ClickOutside/Multiple.razor
+++ b/docs/Tabler.Docs/Components/Helpers/ClickOutside/Multiple.razor
@@ -1,8 +1,7 @@
 ﻿
 <ClickOutside OnClickOutside=@(()=>OutsideClicked("Content 1")) Strategy="ClickOutside.RegisterStrategy.OnClick" Concurrence="ClickOutside.ConcurrenceStrategy.One">
-    <div class="p-1 border" @onclick=@(()=>ShowRegistrationMessage("Content 1"))>
+    <div class="p-1 border">
         <h3>Content 1</h3>
-        I register for click events when you click on me. <br/>
         Click me to register for click event from outside.<br/>
         I will receive only the first click event outside.<br/>
         Click me again to register for another click event from outside.
@@ -31,11 +30,4 @@
     {
         await toastService.AddToastAsync(new ToastModel { Title = @DateTime.Now.ToString("T"), Message = $"You clicked outside container {component}..." });
     }
-
-    private async Task ShowRegistrationMessage(string component)
-    {
-        await toastService.AddToastAsync(new ToastModel { Title = @DateTime.Now.ToString("T"), Message = $"Register for click events outside of container {component}..." });
-
-    }
-
 }

--- a/docs/Tabler.Docs/Tabler.Docs.csproj
+++ b/docs/Tabler.Docs/Tabler.Docs.csproj
@@ -27,4 +27,10 @@
     <ProjectReference Include="..\..\src\TabBlazor\TabBlazor.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="Components\Helpers\ClickOutside\Multiple.razor">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/src/TabBlazor/Components/Utilities/ClickOutside/ClickOutside.razor
+++ b/src/TabBlazor/Components/Utilities/ClickOutside/ClickOutside.razor
@@ -1,5 +1,6 @@
-﻿@using Microsoft.JSInterop
-@inject IJSRuntime JSRuntime;
+﻿@inject IJSRuntime JSRuntime;
+@using Microsoft.JSInterop
+@implements IAsyncDisposable
 @namespace TabBlazor
 
 
@@ -9,6 +10,34 @@
 
 @code {
     private string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    ///     If the clickhandler shall be registered when the component is rendered or when the component is clicked.
+    ///     Default is RegisterStrategy.OnClick.
+    /// </summary>
+    [Parameter]
+    public RegisterStrategy Strategy { get; set; } = RegisterStrategy.OnClick;
+
+    public enum RegisterStrategy
+    {
+        OnClick = 1,
+        OnRender = 2
+    }
+
+    /// <summary>
+    ///     Number of clicks received one or many
+    ///     If ConcurrenceStrategy.One the eventhandler is unregistered after the first click outside.
+    ///     To reduce stress on blazor use RegisterStrategy= OnClick and Concurrence=One
+    /// Default is ConcurrenceStrategy.One
+    /// </summary>
+    [Parameter]
+    public ConcurrenceStrategy Concurrence { get; set; } = ConcurrenceStrategy.One;
+
+    public enum ConcurrenceStrategy
+    {
+        One = 1,
+        Many = 2
+    }
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IReadOnlyDictionary<string, object> Attributes { get; set; }
@@ -25,9 +54,32 @@
         await OnClickOutside.InvokeAsync();
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (firstRender && Strategy == RegisterStrategy.OnRender)
+        {
+            await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, Concurrence == ConcurrenceStrategy.One, DotNetObjectReference.Create(this));
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.removeEvent", Id);
+        }
+        catch (Exception e)
+        {
+        }
+    }
+
     private async Task AddClickOutsideHandler()
     {
-        await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, DotNetObjectReference.Create(this));
+        if (Strategy == RegisterStrategy.OnClick)
+        {
+            await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, Concurrence == ConcurrenceStrategy.One, DotNetObjectReference.Create(this));
+        }
     }
 
 }

--- a/src/TabBlazor/Components/Utilities/ClickOutside/ClickOutside.razor
+++ b/src/TabBlazor/Components/Utilities/ClickOutside/ClickOutside.razor
@@ -1,31 +1,33 @@
-﻿@using Microsoft.JSInterop;
-@inject Microsoft.JSInterop.IJSRuntime JSRuntime;
+﻿@using Microsoft.JSInterop
+@inject IJSRuntime JSRuntime;
 @namespace TabBlazor
 
 
-<span id="@Id" @attributes="@Attributes">
+<span id="@Id" @attributes="@Attributes" @onclick="AddClickOutsideHandler">
     @ChildContent
 </span>
 
 @code {
     private string Id { get; set; } = Guid.NewGuid().ToString();
 
-    [Parameter(CaptureUnmatchedValues = true)] public IReadOnlyDictionary<string, object> Attributes { get; set; }
-    [Parameter] public EventCallback OnClickOutside { get; set; }
-    [Parameter] public RenderFragment ChildContent { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object> Attributes { get; set; }
 
+    [Parameter]
+    public EventCallback OnClickOutside { get; set; }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, DotNetObjectReference.Create(this));
-        }
-    }
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
 
     [JSInvokable]
     public async Task InvokeClickOutside()
     {
         await OnClickOutside.InvokeAsync();
     }
+
+    private async Task AddClickOutsideHandler()
+    {
+        await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, DotNetObjectReference.Create(this));
+    }
+
 }

--- a/src/TabBlazor/wwwroot/js/tabblazor.js
+++ b/src/TabBlazor/wwwroot/js/tabblazor.js
@@ -1,5 +1,4 @@
 ﻿window.tabBlazor = {
-
     getUserAgent: function () {
         return navigator.userAgent;
     },
@@ -7,7 +6,7 @@
     saveAsFile: function (filename, href) {
         var link = document.createElement('a');
         link.download = filename;
-        link.href = href; 
+        link.href = href;
         document.body.appendChild(link); // Needed for Firefox
         link.click();
         document.body.removeChild(link);
@@ -29,11 +28,12 @@
     },
 
     preventDefaultKey: (element, event, keys) => {
-        element.addEventListener(event, (e) => {
-            if (keys.includes(e.key)) {
-                e.preventDefault();
-            }
-        });
+        element.addEventListener(event,
+            (e) => {
+                if (keys.includes(e.key)) {
+                    e.preventDefault();
+                }
+            });
     },
 
     focusFirstInTableRow: (tr) => {
@@ -50,8 +50,7 @@
         var moveToRow = tr;
         if (key == 'ArrowUp') {
             moveToRow = tr.parentNode.rows[tr.rowIndex - 2];
-        }
-        else if (key == 'ArrowDown') {
+        } else if (key == 'ArrowDown') {
             moveToRow = tr.parentNode.rows[tr.rowIndex];
         }
 
@@ -62,11 +61,9 @@
         var pos = td.cellIndex;
         if (key == 'ArrowLeft') {
             pos = pos - 1;
-        }
-        else if (key == 'ArrowRight') {
+        } else if (key == 'ArrowRight') {
             pos = pos + 1;
-        }
-        else if (key == '') {
+        } else if (key == '') {
             key = 'ArrowRight';
         }
 
@@ -82,8 +79,7 @@
             if (focusElement.select) {
                 focusElement.select();
             }
-        }
-        else {
+        } else {
             //Try next
             window.tabBlazor.navigateTable(moveToCell, key);
         }
@@ -127,37 +123,48 @@
 
     disableDraggable: (container, element) => {
 
-        element.addEventListener("mousedown", (e) => {
-            e.stopPropagation();
-            container['draggable'] = false;
-        });
+        element.addEventListener("mousedown",
+            (e) => {
+                e.stopPropagation();
+                container['draggable'] = false;
+            });
 
-        element.addEventListener("mouseup", (e) => {
-            container['draggable'] = true;
-        });
+        element.addEventListener("mouseup",
+            (e) => {
+                container['draggable'] = true;
+            });
 
-        element.addEventListener("mouseleave", (e) => {
-            container['draggable'] = true;
-        });
+        element.addEventListener("mouseleave",
+            (e) => {
+                container['draggable'] = true;
+            });
     },
 
     setPropByElement: (element, property, value) => {
         element[property] = value;
         return "";
     },
-
-
-
+    
     clickOutsideHandler: {
-        addEvent: function (elementId, dotnetHelper) {
-            window.addEventListener("click", (e) => {
-                var element = document.getElementById(elementId);
-                if (e != null && element != null) {
-                    if (e.target.isConnected == true && e.target !== element && (!element.contains(e.target))) {
-                        dotnetHelper.invokeMethodAsync("InvokeClickOutside");
+        removeEvent: () => {
+            if (window.clickOutsideHandler === undefined) return;
+            window.removeEventListener("click", window.clickOutsideHandler);
+            window.clickOutsideHandler = undefined;
+        },
+
+        addEvent: (elementId, dotnetHelper) => {
+            window.tabBlazor.clickOutsideHandler.removeEvent();
+            window.addEventListener("click",
+                window.clickOutsideHandler = (e) => {
+                    
+                    var element = document.getElementById(elementId);
+                    if (e != null && element != null) {
+                        if (e.target.isConnected === true && e.target !== element && (!element.contains(e.target))) {
+                            window.tabBlazor.clickOutsideHandler.removeEvent();
+                            dotnetHelper.invokeMethodAsync("InvokeClickOutside");
+                        }
                     }
-                }
-            });
+                });
         }
     }
 }


### PR DESCRIPTION
_ClickOutside is used to detect clicks outside the component itself and the wrapped content._

ClickOutside supports register for click events outside: 

- OnClick of the content ClickOutside
- OnRender of the ClickOutside

The component can unregister the eventhandler in two ways:
- After the first click outside the component
- When the component is disposed.

Default the component register an event handler when clicked, and unregister the event handler after the first click outside. 
