### PR TITLE
"IsAddInProgress" not reliable

### DIFF
--- a/src/TabBlazor/Components/Tables/Components/Table.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Table.razor.cs
@@ -75,7 +75,7 @@ namespace TabBlazor
         public bool ChangedItem { get; set; }
         public bool AllowAdd => OnItemAdded.HasDelegate;
         public bool AllowDelete => OnItemDeleted.HasDelegate;
-        public bool AllowEdit => OnItemEdited.HasDelegate;
+        public bool AllowEdit => OnItemEdited.HasDelegate && !IsAddInProgress;
         public bool HasGrouping => Columns.Any(x => x.GroupBy);
         public TheGridDataFactory<Item> DataFactory { get; set; }
         public Item SelectedItem { get; set; }


### PR DESCRIPTION
The "IsAddInProgress" is not reliable since it's possible to both add and edit a line at the same time. I may have logic that should only be allowed on add, but now it's also allowed on edit if I'm also currently also adding.

![image](https://user-images.githubusercontent.com/20814046/209243382-815be320-6686-4405-adee-f459359b3917.png)

The second line is setting the "IsAddInProgress" to true. Maybe just block the edit button during add?
![image](https://user-images.githubusercontent.com/20814046/209243447-57d40991-f55a-424b-88c8-c789345bb29f.png)
