### PR TITLE
Fixes to Table and DataProvider

### DIFF
--- a/docs/Tabler.Docs/Components/Tables/TablesExternalDataSourceWithSortingAndPaging.razor
+++ b/docs/Tabler.Docs/Components/Tables/TablesExternalDataSourceWithSortingAndPaging.razor
@@ -1,13 +1,13 @@
-﻿@using TabBlazor.Components.Tables.Components;
-@using TabBlazor.Components.Tables;
+﻿@using TabBlazor.Components.Tables.Components
+@using TabBlazor.Components.Tables
+<Table Item="Item" PageSize="10" Hover Responsive ShowCheckboxes MultiSelect DataProvider="customDataProvider"
+        @bind="SelectedItems">
+     <HeaderTemplate>
+         <strong>Items</strong>
+     </HeaderTemplate>
 
-<Table Item="Item"  PageSize="10" Hover Responsive DataProvider="customDataProvider">
-    <HeaderTemplate>
-        <strong>Items</strong>
-    </HeaderTemplate>
-
-    <ChildContent>
-        <Column Item="Item" Property="e => e.Name" Title="Customer" Sortable >
+     <ChildContent>
+         <Column Item="Item" Property="e => e.Name" Title="Customer" Sortable>
             <EditorTemplate>
                 <input type="text" class="form-control" @bind-value="@context.Name" />
             </EditorTemplate>
@@ -16,24 +16,28 @@
 </Table>
 
 @code {
-   
+
     public class Item
     {
         public Guid Id { get; set; } = Guid.NewGuid();
         public string Name { get; set; }
     }
+    public List<Item> SelectedItems { get; set; }
 
+    private IDataProvider<Item> customDataProvider = new MyCustomDataSource();
 
-
-    private IDataProvider<Item> customDataProvider = new MyCustomDatasource();
-    public class MyCustomDatasource : IDataProvider<Item>
+    public class MyCustomDataSource : IDataProvider<Item>
     {
+        private List<TableResult<object, Item>> viewResult;
+
+        public MyCustomDataSource()
+        {
+            viewResult = new List<TableResult<object, Item>> { new(null, new List<Item> { new() { Name = "my" }, new() { Name = "custom" }, new() { Name = "results" } }) };
+        }
+
         public async Task<IEnumerable<TableResult<object, Item>>> GetData(List<IColumn<Item>> columns, ITableState<Item> state, IEnumerable<Item> items, bool resetPage = false, bool addSorting = true, Item moveToItem = null)
         {
             //here you have to implement your own service call  for data and implement correctly sorting, paging ,grouping to get full benefit of this interface and Table implementation.
-            var viewResult = new List<TableResult<object, Item>>();
-            viewResult.Add(new TableResult<object, Item>(null, new List<Item> { new Item { Name = "my" }, new Item { Name = "custom" }, new Item { Name = "results" } }));
-
             return await Task.FromResult(viewResult);
         }
     }

--- a/src/TabBlazor/Components/Tables/Components/Table.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Table.razor.cs
@@ -30,6 +30,8 @@ namespace TabBlazor
         [Parameter] public string ValidationRuleSet { get; set; } = "default";
         [Parameter] public int PageSize { get; set; } = 20;
         [Parameter] public IList<Item> Items { get; set; }
+        public IList<Item> CurrentItems => Items ?? TempItems?.FirstOrDefault();
+
         [Parameter] public RenderFragment HeaderTemplate { get; set; }
         [Parameter] public RenderFragment ChildContent { get; set; }
         [Parameter] public RenderFragment<Item> DetailsTemplate { get; set; }
@@ -244,9 +246,9 @@ namespace TabBlazor
 
         public async Task SelectAll()
         {
-            if (Items == null || !Items.Any()) return;
+            if (CurrentItems == null || !CurrentItems.Any()) return;
 
-            SelectedItems = Items.ToList();
+            SelectedItems = CurrentItems.ToList();
             SelectedItem = SelectedItems.First();
             await UpdateSelected();
         }

--- a/src/TabBlazor/Components/Tables/Components/TableHeader.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/TableHeader.razor.cs
@@ -36,7 +36,7 @@ namespace TabBlazor.Components.Tables
         protected bool? SelectedValue()
         {
             if (Table.SelectedItems == null || !Table.SelectedItems.Any()) { return false; }
-            if (Table.SelectedItems.Count == Table.Items.Count) { return true; }
+            if (Table.SelectedItems.Count == Table.CurrentItems.Count) { return true; }
             if (Table.SelectedItems.Any()) { return null; }
             return true;
         }

--- a/src/TabBlazor/Components/Tables/Components/TableResult.cs
+++ b/src/TabBlazor/Components/Tables/Components/TableResult.cs
@@ -1,19 +1,17 @@
-﻿using Microsoft.AspNetCore.Components;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace TabBlazor.Components.Tables.Components
+﻿namespace TabBlazor.Components.Tables.Components
 {
     public class TableResult<TKey, TElement> : List<TElement>, IGrouping<TKey, TElement>
     {
+        public bool Expanded = true;
+
         public TableResult(TKey key, List<TElement> elements)
         {
             Key = key;
             AddRange(elements);
         }
 
-        public TKey Key { get; set; }
-        public bool Expanded = true;
         public RenderFragment<TableResult<TKey, TElement>> GroupingTemplate { get; set; }
+
+        public TKey Key { get; set; }
     }
 }

--- a/src/TabBlazor/Components/Tables/Components/TheGridDataFactory.cs
+++ b/src/TabBlazor/Components/Tables/Components/TheGridDataFactory.cs
@@ -14,12 +14,7 @@ namespace TabBlazor.Components.Tables
             {
                 var query = items.AsQueryable();
                 query = AddSearch(columns, state, query);
-                //if (state.CurrentEditItem == null)
-                //{
-                //    query = AddSearch(query);
-                //}
-
-
+           
                 if (addSorting)
                 {
                     query = AddSorting(columns,state,query);

--- a/src/TabBlazor/Components/Tables/ITable.cs
+++ b/src/TabBlazor/Components/Tables/ITable.cs
@@ -16,6 +16,10 @@ namespace TabBlazor.Components.Tables
         int VisibleColumnCount { get; }
         List<TableItem> SelectedItems { get; set; }
         IList<TableItem> Items { get; }
+        /// <summary>
+        /// Contains current items. It is either Items or the data from the dataprovider if dataprovider is used.
+        /// </summary>
+        IList<TableItem> CurrentItems { get; }
         IDataProvider<TableItem> DataProvider { get; set; }
         RenderFragment<TableItem> RowActionTemplate { get; set; }
         bool ShowCheckboxes { get; set; }
@@ -70,7 +74,7 @@ namespace TabBlazor.Components.Tables
         bool IsAddInProgress { get; }
         Task CloseEdit();
         Task CancelEdit();
-        bool IsRowValid { get;}
+        bool IsRowValid { get; }
         Action<TableEditPopupOptions<TItem>> EditPopupMutator { get; set; }
 
     }
@@ -85,7 +89,7 @@ namespace TabBlazor.Components.Tables
         TableItem CurrentEditItem { get; }
         Task CloseEdit();
         Task CancelEdit();
-        bool IsRowValid { get;}
+        bool IsRowValid { get; }
         bool HasActionColumn { get; }
     }
 


### PR DESCRIPTION
Fixed Table and its SelectedItems to be able to work with a Dataprovider instead of Items. 
Previously the SelectedItems worked only with Items.
if user provided a DataProvider instead of items the SelectedItems thrown an exception.
Now the SelectedItems works with either Items or provided custom DataProvider.
