### PR TITLE
Refactor Autocomplete component in TabBlazor

### DIFF
--- a/docs/Tabler.Docs/Components/Forms/Autocomplete/AutocompleteGrouping.razor
+++ b/docs/Tabler.Docs/Components/Forms/Autocomplete/AutocompleteGrouping.razor
@@ -1,9 +1,22 @@
 ﻿@using TabBlazor
 
-<Autocomplete TItem="Order" @bind-Value="customerName" SearchMethod="Search" OnItemSelected="SelectedCustomer" GroupBy="order => order.Country">
+<Autocomplete TItem="Order" @bind-Value="customerName" SearchMethod="Search" OnItemSelected="SelectedCustomer" GroupBy="order => order.Country"  ShowOptionOnFocus="true">
     <ResultTemplate>
-        @context.OrderId : @context.OrderDate
+        Order Customer (@context.OrderId):  @context.Customer.CustomerName
     </ResultTemplate>
+    <NotFoundTemplate>
+        No order with customer name containing @($"'{customerName}'") found
+    </NotFoundTemplate>
+    <GroupingHeaderTemplate>
+        @if (context.ToString() == "Spain")
+        {
+            <Flag Size="FlagSize.XSmall" FlagType="Flags.Spain" class="pe-1"/> @context.ToString()
+        }
+        else
+        {
+            @context.ToString()    
+        }
+    </GroupingHeaderTemplate>
 </Autocomplete>
 
 Name: @customerName
@@ -14,6 +27,7 @@ Name: @customerName
 
     private Task<List<Order>> Search(string arg)
     {
+        arg ??= "";
         var result = orders
             .Where(x => x.Customer.CustomerName.Contains(arg, StringComparison.InvariantCultureIgnoreCase))
             .ToList();
@@ -24,5 +38,4 @@ Name: @customerName
     {
         customerName = order.Customer.CustomerName;
     }
-
 }

--- a/src/TabBlazor/Components/Forms/AutoComplete/Autocomplete.razor
+++ b/src/TabBlazor/Components/Forms/AutoComplete/Autocomplete.razor
@@ -20,22 +20,33 @@
     {
         <ClickOutside OnClickOutside="OnClickOutside">
             <div class="dropdown-menu dropdown-menu-left show dropdown-project">
+                @if (!string.IsNullOrEmpty(ResultHeader))
+                {
+                    <span class="dropdown-header">@ResultHeader</span>
+                }
+                
                 @if (GroupBy != null)
                 {
                     var j = 0;
                     foreach (var searchGroup in GroupedResult)
                     {
-                        <div class="dropdown-item d-flex dropdown-group-header">
-                            <h4 class="ml-3 mb-1">@GroupingHeaderExpression(searchGroup.Key)</h4>
-                            <div class="dropdown-divider"></div>
-                        </div>
-
+                        <span class="dropdown-header">
+                            @if (GroupingHeaderTemplate != null)
+                            {
+                                @GroupingHeaderTemplate(searchGroup.Key)
+                            }
+                            else
+                            {
+                                @GroupingHeaderExpression(searchGroup.Key)    
+                            }
+                            
+                        </span>
                         var items = searchGroup.ToList();
                         for (int i = 0; i < items.Count; i++)
                         {
                             var item = items[i];
-                            <a @key="item" 
-                               class="dropdown-item d-flex clickable @GetSelectedSuggestionClass(item, j)" 
+                            <a @key="item"
+                               class="dropdown-item d-flex clickable @GetSelectedSuggestionClass(item, j)"
                                @onclick="() => OnItemSelectedCallback(item)">
                                 @ResultTemplate(item)
                             </a>
@@ -43,25 +54,15 @@
                         }
                     }
 
-                    @if (!GroupedResult.Any())
+                    if (!GroupedResult.Any())
                     {
                         <a class="dropdown-item d-flex">
                             @NotFoundTemplate
                         </a>
                     }
-
-                    <div class="dropdown-divider"></div>
                 }
                 else
                 {
-                    if (!string.IsNullOrEmpty(ResultHeader))
-                    {
-                        <div class="dropdown-item d-flex dropdown-group-header">
-                            <h5>@ResultHeader</h5>
-                            <div class="dropdown-divider"></div>
-                        </div>
-                    }
-
                     for (int i = 0; i < Result.Count(); i++)
                     {
                         var item = Result[i];

--- a/src/TabBlazor/Components/Forms/AutoComplete/Autocomplete.razor.cs
+++ b/src/TabBlazor/Components/Forms/AutoComplete/Autocomplete.razor.cs
@@ -33,6 +33,8 @@ public partial class Autocomplete<TItem> : TablerBaseComponent, IDisposable
     [Parameter] public int Debounce { get; set; } = 300;
     [Parameter] public Expression<Func<TItem, object>> GroupBy { get; set; }
     [Parameter] public Func<object, string> GroupingHeaderExpression { get; set; }
+    [Parameter] public RenderFragment<object> GroupingHeaderTemplate { get; set; }
+    
     [Parameter] public Func<string, Task<List<TItem>>> SearchMethod { get; set; }
     [Parameter] public EventCallback<TItem> OnItemSelected { get; set; }
     [Parameter] public string SeparatorCharacter { get; set; }


### PR DESCRIPTION
This update modifies the Autocomplete component in TabBlazor, making the results header always display if it's not empty.

Removes the divider after grouped result