### PR TITLE
Add AssemblyScanFilter to TablerOptions

### DIFF
--- a/docs/Tabler.Docs/DocsExtensions.cs
+++ b/docs/Tabler.Docs/DocsExtensions.cs
@@ -12,7 +12,10 @@ namespace Tabler.Docs
         public static IServiceCollection AddDocs(this IServiceCollection services)
         {
             return services
-               .AddTabler()
+               .AddTabler(options =>
+               {
+                   options.AssemblyScanFilter = () => [typeof(IFlagType).Assembly];
+               })
                .AddSingleton<AppService>();
         }
 

--- a/docs/Tabler.Docs/Tabler.Docs.csproj
+++ b/docs/Tabler.Docs/Tabler.Docs.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TabBlazor/Components/Flags/FlagService.cs
+++ b/src/TabBlazor/Components/Flags/FlagService.cs
@@ -1,61 +1,55 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection;
+using Microsoft.Extensions.Options;
 
+namespace TabBlazor;
 
-namespace TabBlazor
+public class FlagService
 {
-    public class FlagService
+    public FlagService(IOptions<TablerOptions> options)
     {
-
-        private List<GeneratedFlag> generatedFlags = new();
-
-        public List<GeneratedFlag> AllFlags => generatedFlags;
-        public List<IFlagType> countryFlagTypes { get; set; }
-
-
-        public IFlagType GetFlagType(int numericCode)
+        foreach (var a in options.Value.AssemblyScanFilter())
         {
-            return countryFlagTypes.FirstOrDefault(e => e.Country.Numeric == numericCode);
-        }
-
-        public IFlagType GetFlagType(string countryCode)
-        {
-            if (string.IsNullOrWhiteSpace(countryCode)) { return null; }
-
-            if (countryCode.Length == 2)
+            foreach (var t in a.GetTypes())
             {
-                return countryFlagTypes.FirstOrDefault(e => e.Country.Alpha2.ToLower() == countryCode.ToLower());
-            }
-
-            if (int.TryParse(countryCode, out var numeric))
-            {
-                return GetFlagType(numeric);
-            }
-
-            return countryFlagTypes.FirstOrDefault(e => e.Country?.Alpha3.ToLower() == countryCode.ToLower());
-        }
-
-        public FlagService()
-        {
-            foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                foreach (Type t in a.GetTypes())
+                foreach (var prop in t.GetProperties(BindingFlags.Static | BindingFlags.Public)
+                             .Where(e => e.PropertyType == typeof(IFlagType)))
                 {
-                    foreach (var prop in t.GetProperties(BindingFlags.Static | BindingFlags.Public).Where(e => e.PropertyType == typeof(IFlagType)))
-                    {
-                        generatedFlags.Add(new GeneratedFlag { Name = prop.Name, FlagType = (IFlagType)prop.GetValue(null) });
-                    }
+                    GeneratedFlags.Add(
+                        new() { Name = prop.Name, FlagType = (IFlagType)prop.GetValue(null) });
                 }
             }
-
-            countryFlagTypes = generatedFlags.Select(e => e.FlagType).Where(f => f.Country != null).ToList();
         }
+
+        CountryFlagTypes = GeneratedFlags.Select(e => e.FlagType).Where(f => f.Country != null).ToList();
     }
 
-  
+    private List<GeneratedFlag> GeneratedFlags { get; set; } = [];
+    private List<IFlagType> CountryFlagTypes { get; set; }
+    public List<GeneratedFlag> AllFlags => GeneratedFlags;
+    
 
+    public IFlagType GetFlagType(int numericCode)
+    {
+        return CountryFlagTypes.FirstOrDefault(e => e.Country.Numeric == numericCode);
+    }
+
+    public IFlagType GetFlagType(string countryCode)
+    {
+        if (string.IsNullOrWhiteSpace(countryCode))
+        {
+            return null;
+        }
+
+        if (countryCode.Length == 2)
+        {
+            return CountryFlagTypes.FirstOrDefault(e => e.Country.Alpha2.ToLower() == countryCode.ToLower());
+        }
+
+        if (int.TryParse(countryCode, out var numeric))
+        {
+            return GetFlagType(numeric);
+        }
+
+        return CountryFlagTypes.FirstOrDefault(e => e.Country?.Alpha3.ToLower() == countryCode.ToLower());
+    }
 }

--- a/src/TabBlazor/General/TablerOptions.cs
+++ b/src/TabBlazor/General/TablerOptions.cs
@@ -1,8 +1,14 @@
-﻿using TabBlazor.Components.Tables;
+﻿using System.Reflection;
+using TabBlazor.Components.Tables;
 
 namespace TabBlazor;
 
 public class TablerOptions
 {
     public OnCancelStrategy DefaultOnCancelStrategy { get; set; } = OnCancelStrategy.AsIs;
+
+    /// <summary>
+    /// For now only used when scanning for flags
+    /// </summary>
+    public Func<List<Assembly>> AssemblyScanFilter { get; set; } = () => AppDomain.CurrentDomain.GetAssemblies().ToList();
 }

--- a/src/TabBlazor/TabBlazor.csproj
+++ b/src/TabBlazor/TabBlazor.csproj
@@ -14,6 +14,7 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageIcon>TabBlazorLogo.png</PackageIcon>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<!--<PropertyGroup>

--- a/src/TabBlazor/TablerExtensions.cs
+++ b/src/TabBlazor/TablerExtensions.cs
@@ -22,7 +22,7 @@ namespace TabBlazor
                 .AddScoped<IModalService, ModalService>()
                 .AddScoped<TableFilterService>()
                 .AddScoped<IFormValidator, TablerDataAnnotationsValidator>()
-             .AddSingleton<FlagService>();
+                .AddSingleton<FlagService>();
         }
 
         public static TabBlazorBuilder AddTabBlazor(this IServiceCollection services, Action<TablerOptions> tablerOptions = null)


### PR DESCRIPTION
Introduced a new property `AssemblyScanFilter` in the `TablerOptions` class to specify custom assembly scanning logic. This change allows for more flexible and targeted assembly scanning, particularly useful when dealing with flags in the application. Updated related extensions to utilize this new option.