### PR TITLE
Add footer visibility condition in Table component

### DIFF
--- a/src/TabBlazor/Components/Tables/Components/Table.razor
+++ b/src/TabBlazor/Components/Tables/Components/Table.razor
@@ -8,7 +8,6 @@
 
 <CascadingValue Value="(ITable<Item>) this" Name="Table">
     <Card>
-
         @if (ShowHeader)
         {
             <CardHeader>
@@ -102,7 +101,7 @@
                 @ChildContent
 
 
-                @if (TotalCount > 0)
+                @if (TotalCount > 0 && ShowFooter)
                 {
                     <div class="card-footer d-flex align-items-center">
                         <Pager Item="Item" />


### PR DESCRIPTION
Updated the Table component to show the footer only when the `ShowFooter` property is true in addition to `TotalCount` being greater than zero. This ensures that the footer is not displayed unnecessarily.