### PR TITLE
Set RenderForm before initializing the EditContext.

### DIFF
--- a/src/TabBlazor/Components/Forms/TablerForm.razor.cs
+++ b/src/TabBlazor/Components/Forms/TablerForm.razor.cs
@@ -55,6 +55,7 @@ namespace TabBlazor
                 return;
             }
 
+            RenderForm = true;
             Validator = GetValidator();
             
             if (EditContext == null || !EditContext.Model.Equals(Model))
@@ -64,8 +65,6 @@ namespace TabBlazor
             }
 
             EditContext.SetFieldCssClassProvider(new TabFieldCssClassProvider());
-
-            RenderForm = true;
         }
         
         private IFormValidator GetValidator() => Validator ?? Provider.GetRequiredService<IFormValidator>();


### PR DESCRIPTION
Moved the RenderForm assignment earlier in the method to ensure the property is set prior to EditContext initialization. This prevents potential issues with the rendering logic relying on an uninitialized EditContext.