### PR TITLE
Add support for custom CSS classes in Icon component

### DIFF
--- a/src/TabBlazor/Components/Icons/Icon.razor.cs
+++ b/src/TabBlazor/Components/Icons/Icon.razor.cs
@@ -12,6 +12,7 @@ namespace TabBlazor
         [Parameter] public bool? Filled { get; set; } 
         [Parameter] public int Rotate { get; set; }
         [Parameter] public string Title { get; set; }
+        [Parameter] public string CssClass { get; set; }
 
         //private bool filled => Filled ?? IconType?.Filled ?? false;
         private double strokeWidth => StrokeWidth ?? IconType?.StrokeWidth ?? 2;
@@ -22,6 +23,7 @@ namespace TabBlazor
         protected override string ClassNames => ClassBuilder
             .AddIf($"{TextColor.GetColorClass("text")}", string.IsNullOrWhiteSpace(Color))
             .AddIf("cursor-pointer", OnClick.HasDelegate)
+            .AddIf(CssClass, !string.IsNullOrWhiteSpace(CssClass))
             .ToString();
     }
 }


### PR DESCRIPTION
Introduced a new `CssClass` parameter to allow users to pass custom CSS classes to the Icon component. The parameter is conditionally applied to the component if it is not null or empty, enabling greater styling flexibility.