### PR TITLE
Update modal accessibility by changing aria-hidden to aria-state

### DIFF
--- a/src/TabBlazor/Components/Modals/ModalView.razor
+++ b/src/TabBlazor/Components/Modals/ModalView.razor
@@ -6,7 +6,7 @@
 
 
 <div class="modal @GetModalWrapperClasses() fade show" id="tabblazor-modal-container" @ref="BlurContainer" @onkeydown="OnKeyDown" @onclick="OnClickOutside"
-     tabindex="-1" style="display: block; z-index: @modalViewSettings.ZIndex" aria-hidden="true">
+     tabindex="-1" style="display: block; z-index: @modalViewSettings.ZIndex" aria-state="modal">
     <div class="@GetModalCss()" role="document" @ondragend="OnDragEnd" @ondragstart="OnDragStart"
          style=@(GetModalStyle()) @ref="dragContainer" @onclick:stopPropagation>
         <div class="modal-content border">


### PR DESCRIPTION
Replaced the `aria-hidden` attribute with `aria-state` in the modal component for better semantic accuracy. This ensures improved alignment with accessibility standards and potential future-proofing for modal handling.

fixes #166