### PR TITLE
Add XML docs and AI-readable package metadata for NuGet consumers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />

--- a/src/TabBlazor.QuickTable.EntityFramework/TabBlazor.QuickTable.EntityFramework.csproj
+++ b/src/TabBlazor.QuickTable.EntityFramework/TabBlazor.QuickTable.EntityFramework.csproj
@@ -5,6 +5,16 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <DebugType>portable</DebugType>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Tenekon.MSBuild.Packaging.ProjectBuildInPackage">

--- a/src/TabBlazor/AGENTS.md
+++ b/src/TabBlazor/AGENTS.md
@@ -1,0 +1,106 @@
+# TabBlazor — AI agent guide
+
+Machine-readable usage notes for AI coding agents consuming the `TabBlazor` NuGet
+package. Goal: enough to wire up the library and use the main components correctly
+without reading the source. For per-symbol detail, read the shipped XML docs
+(`TabBlazor.xml`, next to `TabBlazor.dll` in the package) or step into source via
+Source Link.
+
+- Package: `TabBlazor` (component library), `TabBlazor.QuickTable.EntityFramework` (optional EF Core integration)
+- Root namespace: `TabBlazor`
+- Target: .NET 10, Blazor (Server + WebAssembly). `browser` is a supported platform.
+- UI base: [Tabler](https://preview.tabler.io/) (Bootstrap-based). Minimal JS interop.
+- Live examples with source: https://tabblazor.com
+
+## Setup (required)
+
+1. Register services in `Program.cs`:
+   ```csharp
+   builder.Services.AddTabBlazor(options =>
+   {
+       options.EnablePopper = true; // enables dynamic tooltip/dropdown/popover positioning
+   });
+   ```
+   `AddTabBlazor` returns a `TabBlazorBuilder`. Chain `.AddValidation<TValidator>()`
+   to plug a custom `IFormValidator` (default is DataAnnotations).
+
+2. Add to `_Imports.razor`:
+   ```razor
+   @using TabBlazor
+   ```
+
+3. Reference styles + script in `App.razor` (Server) or `index.html` (WebAssembly):
+   ```html
+   <link rel="stylesheet" href="https://unpkg.com/@tabler/core@1.4.0/dist/css/tabler.min.css" />
+   <link rel="stylesheet" href="_content/TabBlazor/css/tabblazor.min.css" />
+   <script src="_content/TabBlazor/js/tabblazor.js"></script>
+   ```
+
+## Component conventions
+
+- All components inherit `TablerBaseComponent`. Common params: `TextColor`,
+  `BackgroundColor` (both `TablerColor` enum), `ChildContent`, `OnClick`.
+- Unmatched HTML attributes pass through to the root element (`CaptureUnmatchedValues`).
+  A user-supplied `class` is merged with component classes, not replaced.
+- Colors come from the `TablerColor` enum (e.g. `TablerColor.Primary`,
+  `TablerColor.Danger`). Do not hand-write Bootstrap color class strings.
+
+## Common tasks
+
+### Card + button
+```razor
+<Card>
+    <CardHeader><CardTitle>Title</CardTitle></CardHeader>
+    <CardBody>
+        <Button BackgroundColor="TablerColor.Primary" OnClick="Save">Save</Button>
+    </CardBody>
+</Card>
+```
+
+### Show a modal
+Inject `IModalService`, then:
+```csharp
+@inject IModalService ModalService
+
+var result = await ModalService.ShowAsync<MyComponent>(
+    "Title",
+    new RenderComponent<MyComponent>().Set(c => c.SomeParam, value));
+
+if (!result.Cancelled)
+{
+    var data = result.Data; // payload passed to ModalService.Close(ModalResult.Ok(data))
+}
+```
+- Confirm dialogs: `await ModalService.ShowDialogAsync(new DialogOptions { ... })` returns `bool`.
+- Close from inside a modal component: `ModalService.Close(ModalResult.Ok(payload))` or `ModalService.Close()` to cancel.
+
+### Forms
+Use `<TablerForm Model="model" OnValidSubmit="...">` with built-in inputs
+(`TextInput`, `Select`, `Autocomplete`, `Typeahead`, `Datepicker`, etc.).
+Validation is pluggable via `IFormValidator`; DataAnnotations is the default.
+
+### Tables
+- `QuickTable<T>` — virtual-scrolling grid. Supply rows via `GridItemsProvider<T>`.
+  Columns: `PropertyColumn`, `TemplateColumn`. Supports sort/filter/group.
+  Server-side EF Core querying lives in `TabBlazor.QuickTable.EntityFramework`.
+- `Table<T>` — standard table with editable rows, detail rows, grouping, column config.
+
+### Toasts / Offcanvas
+Inject `ToastService` / `IOffcanvasService` (registered by `AddTabBlazor`).
+
+## Registered services (from AddTabBlazor)
+
+`ToastService`, `TablerService` (JS interop), `IOffcanvasService`, `IModalService`,
+`TableFilterService`, `IFormValidator` (default `TablerDataAnnotationsValidator`),
+`FlagService`. `IPopperService` is registered only when `EnablePopper` is true (or a
+non-default `DefaultPositioning` is set).
+
+## Where to look for more
+
+- XML doc comments ship in the package (`TabBlazor.xml`) — primary per-symbol reference.
+- Source Link is enabled: debuggers/agents can fetch exact source for any symbol.
+- Component categories live under `Components/` in the repo: Accordions, Alerts,
+  Avatars, Badges, Buttons, Cards, Carousel, Dashboards, DataGrid, Dimmers, Dropdowns,
+  Flags, Forms, Icons, Inputs, Layouts, Modals, Navbars, Navigation, Offcanvas, Pages,
+  Popovers, Progresses, QuickTables, RangeSliders, Statuses, Tables, Tabs, Timelines,
+  Toasts, Tooltips, TreeViews, Utilities.

--- a/src/TabBlazor/Components/Accordions/Accordion.razor.cs
+++ b/src/TabBlazor/Components/Accordions/Accordion.razor.cs
@@ -1,8 +1,12 @@
 ﻿namespace TabBlazor;
 
+/// <summary>
+/// A container for collapsible <see cref="AccordionItem"/> panels. By default only one item is open at a time.
+/// </summary>
 public partial class Accordion : TablerBaseComponent
 {
     private List<AccordionItem> Items { get; set; } = new();
+    /// <summary>When true, multiple items can be expanded at once. Defaults to false.</summary>
     [Parameter]public bool MultipleOpen { get; set; }
 
     public void AddAccordionItem(AccordionItem item)

--- a/src/TabBlazor/Components/Accordions/AccordionItem.razor.cs
+++ b/src/TabBlazor/Components/Accordions/AccordionItem.razor.cs
@@ -1,13 +1,19 @@
 ﻿namespace TabBlazor;
 
+/// <summary>A single collapsible panel within an <see cref="Accordion"/>.</summary>
 public class AccordionItem : TablerBaseComponent, IDisposable
 {
+    /// <summary>The parent accordion, supplied via cascading parameter.</summary>
     [CascadingParameter(Name = "Accordion")]
     public Accordion Accordion { get; set; }
 
+    /// <summary>The header text. Ignored when <see cref="TitleTemplate"/> is set.</summary>
     [Parameter] public string Title { get; set; }
+    /// <summary>Optional custom header content, overriding <see cref="Title"/>.</summary>
     [Parameter] public RenderFragment TitleTemplate { get; set; }
+    /// <summary>Whether the item starts expanded. Defaults to false.</summary>
     [Parameter] public bool Expanded { get; set; }
+    /// <summary>The current expanded state.</summary>
     public bool IsExpanded { get; set; }
 
    

--- a/src/TabBlazor/Components/Alerts/Alert.razor.cs
+++ b/src/TabBlazor/Components/Alerts/Alert.razor.cs
@@ -2,10 +2,16 @@
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A contextual alert message box. Color is taken from <see cref="TablerBaseComponent.BackgroundColor"/>.
+    /// </summary>
     public partial class Alert : TablerBaseComponent
     {
+        /// <summary>The alert title shown in bold above the content.</summary>
         [Parameter] public string Title { get; set; }
+        /// <summary>When true, shows a close button that dismisses the alert. Defaults to false.</summary>
         [Parameter] public bool Dismissible { get; set; }
+        /// <summary>When true, renders the high-emphasis (solid) alert style. Defaults to false.</summary>
         [Parameter] public bool Important { get; set; }
         private bool dismissed;
 

--- a/src/TabBlazor/Components/Avatars/Avatar.razor.cs
+++ b/src/TabBlazor/Components/Avatars/Avatar.razor.cs
@@ -3,29 +3,49 @@ using Microsoft.AspNetCore.Components;
 
 namespace TabBlazor
 {
+    /// <summary>The size of an <see cref="Avatar"/>.</summary>
     public enum AvatarSize
     {
+        /// <summary>Standard size.</summary>
         Default,
+        /// <summary>Small.</summary>
         Small,
+        /// <summary>Medium.</summary>
         Medium,
+        /// <summary>Large.</summary>
         Large,
+        /// <summary>Extra large.</summary>
         ExtraLarge
     }
 
+    /// <summary>The corner rounding of an <see cref="Avatar"/>.</summary>
     public enum AvatarRounded
     {
+        /// <summary>Theme default rounding.</summary>
         Default,
+        /// <summary>Rounded corners.</summary>
         Rounded,
+        /// <summary>Slightly rounded corners.</summary>
         RoundedSmall,
+        /// <summary>Largely rounded corners.</summary>
         RoundedLarge,
+        /// <summary>Fully circular.</summary>
         Circle,
+        /// <summary>Square (no rounding).</summary>
         None
     }
 
+    /// <summary>
+    /// A user/entity avatar showing an image or initials. Set <see cref="Data"/> to an image URL, or place
+    /// initials in child content. Background/text color come from <see cref="TablerBaseComponent"/>.
+    /// </summary>
     public partial class Avatar : TablerBaseComponent
     {
+        /// <summary>Image URL shown as the avatar background. When empty, child content (e.g. initials) is shown.</summary>
         [Parameter] public string Data { get; set; } = "";
+        /// <summary>The avatar size. Defaults to <see cref="AvatarSize.Default"/>.</summary>
         [Parameter] public AvatarSize Size { get; set; } = AvatarSize.Default;
+        /// <summary>The corner rounding. Defaults to <see cref="AvatarRounded.Default"/>.</summary>
         [Parameter] public AvatarRounded Rounded { get; set; } = AvatarRounded.Default;
 
         protected string Style => string.IsNullOrWhiteSpace(Data) ? string.Empty : $"{GetUnmatchedParameter("style")} background-image:url('{Data}')";

--- a/src/TabBlazor/Components/Avatars/AvatarList.razor.cs
+++ b/src/TabBlazor/Components/Avatars/AvatarList.razor.cs
@@ -2,8 +2,10 @@
 
 namespace TabBlazor
 {
+    /// <summary>A container that lays out multiple <see cref="Avatar"/> components in a row.</summary>
     public partial class AvatarList : TablerBaseComponent
     {
+        /// <summary>When true, avatars overlap in a stacked layout. Defaults to false.</summary>
         [Parameter] public bool Stacked { get; set; }
         protected override string ClassNames => ClassBuilder
             .Add("avatar-list")

--- a/src/TabBlazor/Components/Badges/Badge.razor.cs
+++ b/src/TabBlazor/Components/Badges/Badge.razor.cs
@@ -4,33 +4,51 @@ using Microsoft.AspNetCore.Components.Rendering;
 
 namespace TabBlazor
 {
+    /// <summary>The corner style of a <see cref="Badge"/>.</summary>
     public enum BadgeShape
     {
+        /// <summary>Standard rounded corners.</summary>
         Default,
+        /// <summary>Fully rounded pill shape.</summary>
         Pill
     }
 
+    /// <summary>The size of a <see cref="Badge"/>.</summary>
     public enum BadgeSize
     {
+        /// <summary>Standard size.</summary>
         Default,
+        /// <summary>Larger badge.</summary>
         Large
     }
 
+    /// <summary>The visual style of a <see cref="Badge"/>.</summary>
     public enum BadgeType
     {
+        /// <summary>Solid filled badge.</summary>
         Default,
+        /// <summary>Light tinted background.</summary>
         Light,
+        /// <summary>Outlined with transparent background.</summary>
         Outline
     }
 
 
+    /// <summary>
+    /// A small count/label badge. Color comes from <see cref="TablerBaseComponent.BackgroundColor"/>.
+    /// </summary>
     public partial class Badge : TablerBaseComponent
     {
+        /// <summary>The corner style. Defaults to <see cref="BadgeShape.Default"/>.</summary>
         [Parameter] public BadgeShape Shape { get; set; }
+        /// <summary>The badge size. Defaults to <see cref="BadgeSize.Default"/>.</summary>
         [Parameter] public BadgeSize Size { get; set; } = BadgeSize.Default;
+        /// <summary>The visual style (solid, light, outline). Defaults to <see cref="BadgeType.Default"/>.</summary>
         [Parameter] public BadgeType BadgeType { get; set; } = BadgeType.Default;
 
+        /// <summary>When true, renders as a small notification dot. Defaults to false.</summary>
         [Parameter] public bool Notification { get; set; }
+        /// <summary>When true, the badge blinks to draw attention. Defaults to false.</summary>
         [Parameter] public bool Blink { get; set; }
 
         protected string HtmlTag => "span";

--- a/src/TabBlazor/Components/Buttons/Button.razor.cs
+++ b/src/TabBlazor/Components/Buttons/Button.razor.cs
@@ -2,41 +2,98 @@
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Defines the corner style of a <see cref="Button"/>.
+    /// </summary>
     public enum ButtonShape
     {
+        /// <summary>Standard rounded button corners.</summary>
         Default,
+        /// <summary>Square (non-rounded) corners.</summary>
         Square,
+        /// <summary>Fully rounded pill-shaped corners.</summary>
         Pill
     }
 
+    /// <summary>
+    /// Defines the size of a <see cref="Button"/>.
+    /// </summary>
     public enum ButtonSize
     {
+        /// <summary>Standard button size.</summary>
         Default,
+        /// <summary>Larger button.</summary>
         Large,
+        /// <summary>Smaller button.</summary>
         Small
     }
 
+    /// <summary>
+    /// Defines the rendered HTML element and behavior of a <see cref="Button"/>.
+    /// </summary>
     public enum ButtonType
     {
+        /// <summary>Renders an anchor (&lt;a&gt;) element, typically used with <see cref="Button.LinkTo"/>.</summary>
         Link,
+        /// <summary>Renders a standard &lt;button&gt; element.</summary>
         Button,
+        /// <summary>Renders an &lt;input type="button"&gt; element.</summary>
         Input,
+        /// <summary>Renders an &lt;input type="submit"&gt; element that submits the enclosing form.</summary>
         Submit,
+        /// <summary>Renders an &lt;input type="reset"&gt; element that resets the enclosing form.</summary>
         Reset
     }
 
+    /// <summary>
+    /// A clickable button that can render as a button, input, or link. Supports colors, sizes, shapes,
+    /// icon-only and loading states.
+    /// </summary>
     public partial class Button : TablerBaseComponent
     {
+        /// <summary>
+        /// The text label shown on the button. Ignored when <see cref="TablerBaseComponent.ChildContent"/> is set.
+        /// </summary>
         [Parameter] public string Text { get; set; }
+        /// <summary>
+        /// When <c>true</c>, the button is disabled and cannot be clicked. Defaults to <c>false</c>.
+        /// </summary>
         [Parameter] public bool Disabled { get; set; }
+        /// <summary>
+        /// When <c>true</c>, the button stretches to the full width of its container. Defaults to <c>false</c>.
+        /// </summary>
         [Parameter] public bool Block { get; set; }
+        /// <summary>
+        /// When <c>true</c>, renders the button as an icon-only button (square, sized for a single icon). Defaults to <c>false</c>.
+        /// </summary>
         [Parameter] public bool IsIcon { get; set; }
+        /// <summary>
+        /// When <c>true</c>, shows a loading spinner on the button. Defaults to <c>false</c>.
+        /// </summary>
         [Parameter] public bool IsLoading { get; set; }
+        /// <summary>
+        /// When <c>true</c>, renders the button as a dropdown toggle (adds a caret). Defaults to <c>false</c>.
+        /// </summary>
         [Parameter] public bool IsDropdown { get; set; }
+        /// <summary>
+        /// Controls how <see cref="TablerBaseComponent.BackgroundColor"/> is applied (e.g. solid, outline, ghost). Defaults to <see cref="ColorType.Default"/>.
+        /// </summary>
         [Parameter] public ColorType BackgroundColorType { get; set; } = ColorType.Default;
+        /// <summary>
+        /// The corner shape of the button. Defaults to <see cref="ButtonShape.Default"/>.
+        /// </summary>
         [Parameter] public ButtonShape Shape { get; set; } = ButtonShape.Default;
+        /// <summary>
+        /// The size of the button. Defaults to <see cref="ButtonSize.Default"/>.
+        /// </summary>
         [Parameter] public ButtonSize Size { get; set; } = ButtonSize.Default;
+        /// <summary>
+        /// The rendered element and behavior of the button. Defaults to <see cref="ButtonType.Button"/>.
+        /// </summary>
         [Parameter] public ButtonType Type { get; set; } = ButtonType.Button;
+        /// <summary>
+        /// The URL navigated to when <see cref="Type"/> is <see cref="ButtonType.Link"/>.
+        /// </summary>
         [Parameter] public string LinkTo { get; set; }
 
         protected string HtmlTag => Type switch

--- a/src/TabBlazor/Components/Cards/Card.razor.cs
+++ b/src/TabBlazor/Components/Cards/Card.razor.cs
@@ -2,27 +2,53 @@
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Overall sizing of a <see cref="Card"/>, controlling its padding scale.
+    /// </summary>
     public enum CardSize
     {
+        /// <summary>Standard card padding.</summary>
         Default,
+        /// <summary>Compact card with reduced padding.</summary>
         Small,
+        /// <summary>Medium card padding.</summary>
         Medium,
+        /// <summary>Large card with increased padding.</summary>
         Large
     }
 
+    /// <summary>
+    /// Edge along which a card's colored status indicator is rendered.
+    /// </summary>
     public enum CardStatusPosition
     {
+        /// <summary>Status bar along the left edge.</summary>
         Left,
+        /// <summary>Status bar along the top edge.</summary>
         Top,
+        /// <summary>Status bar along the bottom edge.</summary>
         Bottom
     }
+
+    /// <summary>
+    /// Tabler card container that groups related content. Compose with
+    /// <see cref="CardHeader"/>, <see cref="CardBody"/>, <see cref="CardFooter"/> and related child components.
+    /// </summary>
     public partial class Card : TablerBaseComponent
     {
+        /// <summary>Padding scale of the card. Defaults to <see cref="CardSize.Default"/>.</summary>
         [Parameter] public CardSize Size { get; set; } = CardSize.Default;
+
+        /// <summary>When <c>true</c>, renders the card with a stacked (layered) visual effect. Defaults to <c>false</c>.</summary>
         [Parameter] public bool Stacked { get; set; }
+
+        /// <summary>Color of a status bar drawn along the top edge. Defaults to <see cref="TablerColor.Default"/>, which hides the bar.</summary>
         [Parameter] public TablerColor StatusTop { get; set; } = TablerColor.Default;
+
+        /// <summary>Color of a status bar drawn along the start (left) edge. Defaults to <see cref="TablerColor.Default"/>, which hides the bar.</summary>
         [Parameter] public TablerColor StatusStart { get; set; } = TablerColor.Default;
-      
+
+        /// <summary>When set, renders the card as an anchor linking to this URL instead of a plain <c>div</c>.</summary>
         [Parameter] public string LinkTo { get; set; }
 
         protected string HtmlTag => string.IsNullOrWhiteSpace(LinkTo)

--- a/src/TabBlazor/Components/Cards/CardBody.razor.cs
+++ b/src/TabBlazor/Components/Cards/CardBody.razor.cs
@@ -1,5 +1,8 @@
 ﻿namespace TabBlazor
 {
+    /// <summary>
+    /// Main content area of a <see cref="Card"/>. Place inside a <see cref="Card"/>.
+    /// </summary>
     public partial class CardBody : TablerBaseComponent
     {
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Cards/CardRibbon.razor.cs
+++ b/src/TabBlazor/Components/Cards/CardRibbon.razor.cs
@@ -1,14 +1,19 @@
 ﻿
 namespace TabBlazor
 {
+    /// <summary>Where a <see cref="CardRibbon"/> is placed on its card.</summary>
     public enum RibbonPosition
     {
+        /// <summary>Top corner.</summary>
         Top,
+        /// <summary>Right edge.</summary>
         Right
     }
 
+    /// <summary>A decorative ribbon overlaid on a <c>Card</c>. Color comes from <see cref="TablerBaseComponent.BackgroundColor"/>.</summary>
     public partial class CardRibbon : TablerBaseComponent
     {
+        /// <summary>The ribbon position. Defaults to <see cref="RibbonPosition.Right"/>.</summary>
         [Parameter] public RibbonPosition Position { get; set; } = RibbonPosition.Right;
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Cards/CardTitle.razor.cs
+++ b/src/TabBlazor/Components/Cards/CardTitle.razor.cs
@@ -2,8 +2,10 @@
 
 namespace TabBlazor
 {
+    /// <summary>The title heading within a <c>Card</c> or <c>CardHeader</c>.</summary>
     public partial class CardTitle : TablerBaseComponent
     {
+        /// <summary>The HTML heading element to render. Defaults to <c>"h1"</c>.</summary>
         [Parameter] public string HtmlTag { get; set; } = "h1";
         protected override string ClassNames => ClassBuilder
             .Add("card-title")

--- a/src/TabBlazor/Components/Carousel/Carousel.razor.cs
+++ b/src/TabBlazor/Components/Carousel/Carousel.razor.cs
@@ -3,22 +3,32 @@ using System.Timers;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A slideshow of <see cref="CarouselItem"/> panels with optional controls, indicators and auto-advance.
+    /// </summary>
     public partial class Carousel : IDisposable
     {
         private List<CarouselItem> carouselItems { get; set; } = new();
         private System.Timers.Timer slideTimer = new System.Timers.Timer();
         internal CarouselItem activeItem;
 
+        /// <summary>The carousel items.</summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
+        /// <summary>When true, shows previous/next controls. Defaults to false.</summary>
         [Parameter] public bool Controls { get; set; }
+        /// <summary>The indicator style (none, dots, thumbnails).</summary>
         [Parameter] public CarouselIndicator Indicators { get; set; }
+        /// <summary>The orientation of the indicators.</summary>
         [Parameter] public CarouselIndicatorDirection IndicatorsDirection { get; set; }
 
 
 
+        /// <summary>Time between auto-advance slides, in milliseconds. Defaults to 5000.</summary>
         [Parameter] public int SlideInterval { get; set; } = 5000;
+        /// <summary>When true, slides advance automatically. Defaults to true.</summary>
         [Parameter] public bool AutoSlide { get; set; } = true;
+        /// <summary>Raised when the active item changes.</summary>
         [Parameter] public EventCallback<CarouselItem> OnItemActive { get; set; }
 
         public CarouselItem ActiveItem => activeItem;
@@ -105,6 +115,7 @@ namespace TabBlazor
 
         }
 
+        /// <summary>Activates the item at the given index.</summary>
         public void SetActiveItem(int index)
         {
             var item = carouselItems.ElementAtOrDefault(index);
@@ -114,6 +125,7 @@ namespace TabBlazor
             }
         }
 
+        /// <summary>Activates the given item.</summary>
         public void SetActiveItem(CarouselItem item)
         {
             activeItem = item;
@@ -131,6 +143,7 @@ namespace TabBlazor
             });
         }
 
+        /// <summary>Advances to the next item, wrapping to the first.</summary>
         public void MoveNext()
         {
             if (carouselItems.Count == 0) { return; }
@@ -148,6 +161,7 @@ namespace TabBlazor
         }
 
 
+        /// <summary>Moves to the previous item, wrapping to the last.</summary>
         public void MovePrevious()
         {
             if (carouselItems.Count == 0) { return; }

--- a/src/TabBlazor/Components/Carousel/CarouselItem.razor.cs
+++ b/src/TabBlazor/Components/Carousel/CarouselItem.razor.cs
@@ -2,20 +2,26 @@ using System.Xml.Serialization;
 
 namespace TabBlazor
 {
+    /// <summary>A single slide within a <see cref="Carousel"/>.</summary>
     public partial class CarouselItem : IDisposable
     {
 
         [CascadingParameter] Carousel Carousel { get; set; }
 
+        /// <summary>Image URL shown for the slide.</summary>
         [Parameter] public string ImageSrc { get; set; }
+        /// <summary>Custom slide content, rendered instead of just the image.</summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
+        /// <summary>Optional custom indicator content for this slide.</summary>
         [Parameter] public RenderFragment IndicatorTemplate { get; set; }
 
+        /// <summary>Optional caption content overlaid on the slide.</summary>
         [Parameter] public RenderFragment CaptionTemplate { get; set; }
 
 
 
+        /// <summary>Arbitrary data associated with the slide.</summary>
         [Parameter] public object Data { get; set; }
 
 

--- a/src/TabBlazor/Components/Dashboards/BaseFacet.cs
+++ b/src/TabBlazor/Components/Dashboards/BaseFacet.cs
@@ -2,15 +2,25 @@
 
 namespace TabBlazor.Dashboards
 {
+    /// <summary>
+    /// Base class for dashboard facets — collapsible filter groups that contribute predicates to a
+    /// <see cref="Dashboard{TItem}"/>.
+    /// </summary>
     public class BaseFacet<TItem> : ComponentBase where TItem : class
     {
+        /// <summary>The owning dashboard, supplied via cascading parameter.</summary>
         [CascadingParameter] public Dashboard<TItem> Dashboard { get; set; }
+        /// <summary>The facet's display name.</summary>
         [Parameter] public string Name { get; set; }
+        /// <summary>Whether the facet starts collapsed. Defaults to false.</summary>
         [Parameter] public bool Collapsed { get; set; }
+        /// <summary>Optional custom rendering for the facet, receiving its data.</summary>
         [Parameter] public RenderFragment<DataFacet<TItem>> FacetTemplate { get; set; }
 
+        /// <summary>Projects a filter to its display label.</summary>
         [Parameter] public Func<FacetFilter<TItem>, string> FilterLabel { get; set; }
 
+        /// <summary>Optional custom ordering of the facet's filters.</summary>
         [Parameter] public Func<IEnumerable<FacetFilter<TItem>>, IEnumerable<FacetFilter<TItem>>> SortFilters { get; set; }
 
 

--- a/src/TabBlazor/Components/Dashboards/Dashboard.razor.cs
+++ b/src/TabBlazor/Components/Dashboards/Dashboard.razor.cs
@@ -2,21 +2,33 @@ using System.Diagnostics;
 
 namespace TabBlazor.Dashboards;
 
+/// <summary>
+/// A faceted-filtering dashboard over a set of <typeparamref name="TItem"/> records. Child facets
+/// (<see cref="EqualFacet{TItem}"/>, <see cref="DateFacet{TItem}"/>, etc.) and filters narrow
+/// <see cref="FilteredItems"/>; bind your visuals to that. <typeparamref name="TItem"/> is the record type.
+/// </summary>
 public partial class Dashboard<TItem> where TItem : class
 {
     private readonly List<DataFacet<TItem>> facets = new();
     private readonly List<DataFilter<TItem>> filters = new();
 
+    /// <summary>Time taken by the last <see cref="RunFilter"/> pass, in milliseconds.</summary>
     public long LastRunFilterMilliseconds;
+    /// <summary>The full source data set.</summary>
     [Parameter] public IEnumerable<TItem> Items { get; set; }
+    /// <summary>Dashboard content (facets, filters, visuals), receiving the dashboard as context.</summary>
     [Parameter] public RenderFragment<Dashboard<TItem>> ChildContent { get; set; }
 
+    /// <summary>Raised after the filtered result set changes.</summary>
     [Parameter] public EventCallback OnUpdate { get; set; }
 
+    /// <summary>When true, writes filter timing to the console. Defaults to false.</summary>
     [Parameter] public bool Debug { get; set; }
 
+    /// <summary>The items remaining after all active facets and filters are applied.</summary>
     public IQueryable<TItem> FilteredItems { get; private set; }
 
+    /// <summary>The complete, unfiltered item set.</summary>
     public IQueryable<TItem> AllItems { get; private set; }
 
 
@@ -100,6 +112,7 @@ public partial class Dashboard<TItem> where TItem : class
     }
 
 
+    /// <summary>Re-applies all active filters and facets, updating <see cref="FilteredItems"/> and raising <see cref="OnUpdate"/>.</summary>
     public void RunFilter()
     {
         var sw = new Stopwatch();

--- a/src/TabBlazor/Components/Dashboards/DashboardComponent.cs
+++ b/src/TabBlazor/Components/Dashboards/DashboardComponent.cs
@@ -2,9 +2,15 @@
 
 namespace TabBlazor.Dashboards
 {
+    /// <summary>
+    /// Base class for components that live inside a <see cref="Dashboard{TItem}"/> and access it via cascading
+    /// parameter. Throws if used outside a dashboard.
+    /// </summary>
     public class DashboardComponent<TItem> :  ComponentBase where TItem : class
     {
+        /// <summary>The owning dashboard, supplied via cascading parameter.</summary>
         [CascadingParameter] public Dashboard<TItem> Dashboard { get; set; }
+        /// <summary>Content rendered with the dashboard as context.</summary>
         [Parameter] public RenderFragment<Dashboard<TItem>> ChildContent { get; set; }
       
 

--- a/src/TabBlazor/Components/Dashboards/DateFacet.razor.cs
+++ b/src/TabBlazor/Components/Dashboards/DateFacet.razor.cs
@@ -2,8 +2,10 @@ using Microsoft.AspNetCore.Components.Web;
 
 namespace TabBlazor.Dashboards
 {
+    /// <summary>A dashboard facet that filters by date buckets derived from a <see cref="DateTime"/> property.</summary>
     public partial class DateFacet<TItem> : BaseFacet<TItem> where TItem : class
     {
+        /// <summary>The date property to facet on.</summary>
         [Parameter] public Expression<Func<TItem, DateTime>> Expression { get; set; }
         
 

--- a/src/TabBlazor/Components/Dashboards/EqualFacet.razor.cs
+++ b/src/TabBlazor/Components/Dashboards/EqualFacet.razor.cs
@@ -1,7 +1,9 @@
 namespace TabBlazor.Dashboards;
 
+/// <summary>A dashboard facet that filters by distinct values of a property (one filter per value).</summary>
 public partial class EqualFacet<TItem> : BaseFacet<TItem> where TItem : class
 {
+    /// <summary>The property whose distinct values become filter options.</summary>
     [Parameter] public Expression<Func<TItem, object>> Expression { get; set; }
 
     protected override void OnInitialized()

--- a/src/TabBlazor/Components/Dashboards/GroupFacet.razor.cs
+++ b/src/TabBlazor/Components/Dashboards/GroupFacet.razor.cs
@@ -2,11 +2,14 @@
 
 namespace TabBlazor.Dashboards
 {
+    /// <summary>A dashboard facet that buckets a numeric property into a fixed number of range groups.</summary>
     public partial class GroupFacet<TItem> : BaseFacet<TItem> where TItem : class
     {
+        /// <summary>The numeric property to group on.</summary>
         [Parameter] public Expression<Func<TItem, decimal>> Expression { get; set; }
-     
 
+
+        /// <summary>The number of range buckets to create. Defaults to 5.</summary>
         [Parameter] public int NumberOfGroups { get; set; } = 5;
 
         protected override void OnInitialized()

--- a/src/TabBlazor/Components/Dashboards/RangeFilter.razor.cs
+++ b/src/TabBlazor/Components/Dashboards/RangeFilter.razor.cs
@@ -2,9 +2,12 @@
 
 namespace TabBlazor.Dashboards
 {
+    /// <summary>A dashboard filter with min/max inputs that constrains a numeric property to a range.</summary>
     public partial class RangeFilter<TItem> : DashboardComponent<TItem> where TItem : class
     {
+        /// <summary>The numeric property to constrain.</summary>
         [Parameter] public Expression<Func<TItem, decimal>> Expression { get; set; }
+        /// <summary>The filter's display name.</summary>
         [Parameter] public string Name { get; set; }
 
         private decimal allMin;
@@ -13,6 +16,7 @@ namespace TabBlazor.Dashboards
         private decimal min;
         private decimal max;
 
+        /// <summary>Optional custom content rendered for the filter.</summary>
         [Parameter] public RenderFragment<DataFacet<TItem>> Facet { get; set; }
      
         private DataFilter<TItem> filter;

--- a/src/TabBlazor/Components/Dashboards/StringContainsFacet.razor.cs
+++ b/src/TabBlazor/Components/Dashboards/StringContainsFacet.razor.cs
@@ -1,8 +1,11 @@
 namespace TabBlazor.Dashboards;
 
+/// <summary>A dashboard facet that filters by whether a string-collection property contains given values.</summary>
 public partial class StringContainsFacet<TItem> : BaseFacet<TItem> where TItem : class
 {
+    /// <summary>The string-collection property to facet on.</summary>
     [Parameter] public Expression<Func<TItem, IEnumerable<string>>> Expression { get; set; }
+    /// <summary>Optional comparer controlling case sensitivity of matches.</summary>
     [Parameter] public StringComparer StringComparer { get; set; }
 
     protected override void OnInitialized()

--- a/src/TabBlazor/Components/DataGrid/DataGridItem.razor.cs
+++ b/src/TabBlazor/Components/DataGrid/DataGridItem.razor.cs
@@ -2,10 +2,13 @@
 
 namespace TabBlazor
 {
+    /// <summary>A single labelled field within a datagrid layout (a title plus its content).</summary>
     public partial class DataGridItem : TablerBaseComponent
     {
+        /// <summary>The field label. Ignored when <see cref="TitleTemplate"/> is set.</summary>
         [Parameter] public string Title { get; set; }
-     
+
+        /// <summary>Optional custom title content, overriding <see cref="Title"/>.</summary>
         [Parameter] public RenderFragment TitleTemplate { get; set; }
 
 

--- a/src/TabBlazor/Components/Dimmers/Dimmer.razor.cs
+++ b/src/TabBlazor/Components/Dimmers/Dimmer.razor.cs
@@ -2,9 +2,14 @@
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Overlays its content with a dimming layer and optional spinner, used to indicate a loading/busy state.
+    /// </summary>
     public partial class Dimmer : TablerBaseComponent
     {
+        /// <summary>When true, the dimmer overlay is shown. Defaults to false.</summary>
         [Parameter] public bool Active { get; set; }
+        /// <summary>When true, shows a spinner while active. Defaults to true.</summary>
         [Parameter] public bool ShowSpinner { get; set; } = true;
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Dropdowns/Dropdown.razor.cs
+++ b/src/TabBlazor/Components/Dropdowns/Dropdown.razor.cs
@@ -6,16 +6,28 @@ using TabBlazor.Services;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A toggleable dropdown menu. Place the trigger in child content and the menu in <see cref="DropdownTemplate"/>.
+    /// When <see cref="Positioning"/> requires it, uses Popper (enable via <c>TablerOptions.EnablePopper</c>).
+    /// </summary>
     public partial class Dropdown : TablerBaseComponent, IAsyncDisposable
     {
+        /// <summary>The dropdown menu content (typically a <c>DropdownMenu</c>).</summary>
         [Parameter] public RenderFragment DropdownTemplate { get; set; }
+        /// <summary>When true, the dropdown closes after an item is clicked. Defaults to true.</summary>
         [Parameter] public bool CloseOnClick { get; set; } = true;
+        /// <summary>The direction the menu opens.</summary>
         [Parameter] public DropdownDirection Direction { get; set; }
+        /// <summary>The direction sub-menus open. Defaults to <see cref="DropdownDirection.End"/>.</summary>
         [Parameter] public DropdownDirection SubMenusDirection { get; set; } = DropdownDirection.End;
+        /// <summary>Raised when the dropdown opens or closes.</summary>
         [Parameter] public EventCallback<bool> OnExpanded { get; set; }
 
+        /// <summary>Positioning strategy. When null, uses the configured default.</summary>
         [Parameter] public Positioning? Positioning { get; set; }
+        /// <summary>Popper placement of the menu. Defaults to <see cref="Placement.BottomStart"/>.</summary>
         [Parameter] public Placement Placement { get; set; } = Placement.BottomStart;
+        /// <summary>Popper offset in pixels. Defaults to 2.</summary>
         [Parameter] public int PopperOffset { get; set; } = 2;
 
         [Inject] private IServiceProvider ServiceProvider { get; set; }
@@ -23,6 +35,7 @@ namespace TabBlazor
         private Positioning EffectivePositioning =>
             Positioning ?? Options.CurrentValue.DefaultPositioning;
 
+        /// <summary>True while the dropdown is open.</summary>
         public bool IsExpanded => isExpanded;
 
         protected bool isExpanded;
@@ -107,16 +120,19 @@ namespace TabBlazor
             Toogle();
         }
 
+        /// <summary>Toggles the dropdown open/closed.</summary>
         public void Toogle()
         {
             SetExpanded(!isExpanded);
         }
 
+        /// <summary>Opens the dropdown.</summary>
         public void Open()
         {
             SetExpanded(true);
         }
 
+        /// <summary>Opens the dropdown as a context menu positioned at the mouse event coordinates.</summary>
         public void OpenAsContextMenu(MouseEventArgs e)
         {
             isContextMenu = true;
@@ -126,6 +142,7 @@ namespace TabBlazor
             InvokeAsync(StateHasChanged);
         }
 
+        /// <summary>Closes the dropdown.</summary>
         public void Close()
         {
             SetExpanded(false);

--- a/src/TabBlazor/Components/Dropdowns/DropdownItem.razor.cs
+++ b/src/TabBlazor/Components/Dropdowns/DropdownItem.razor.cs
@@ -6,14 +6,21 @@ using System.Linq;
 
 namespace TabBlazor
 {
+    /// <summary>A single selectable item within a <see cref="DropdownMenu"/>, optionally with a sub-menu.</summary>
     public partial class DropdownItem : TablerBaseComponent, IDisposable
     {
+        /// <summary>The owning dropdown, supplied via cascading parameter.</summary>
         [CascadingParameter(Name = "Dropdown")] public Dropdown Dropdown { get; set; }
+        /// <summary>The parent menu, supplied via cascading parameter.</summary>
         [CascadingParameter(Name = "DropdownMenu")] public DropdownMenu ParentMenu { get; set; }
+        /// <summary>When true, marks the item as active. Defaults to false.</summary>
         [Parameter] public bool Active { get; set; }
+        /// <summary>When true, the item is disabled. Defaults to false.</summary>
         [Parameter] public bool Disabled { get; set; }
+        /// <summary>When true, highlights the item. Defaults to false.</summary>
         [Parameter] public bool Highlight { get; set; }
 
+        /// <summary>Optional nested sub-menu content shown on hover/click.</summary>
         [Parameter] public RenderFragment SubMenu { get; set; }
         private List<DropdownItem> subItems = new();
 

--- a/src/TabBlazor/Components/Dropdowns/DropdownMenu.razor.cs
+++ b/src/TabBlazor/Components/Dropdowns/DropdownMenu.razor.cs
@@ -6,10 +6,14 @@ using System.Linq;
 
 namespace TabBlazor
 {
+    /// <summary>The menu container holding <see cref="DropdownItem"/> entries inside a <see cref="Dropdown"/>.</summary>
     public partial class DropdownMenu : TablerBaseComponent, IDisposable
     {
+        /// <summary>When true, shows a pointer arrow on the menu. Defaults to false.</summary>
         [Parameter] public bool Arrow { get; set; } = false;
+        /// <summary>When true, styles the menu as a card. Defaults to false.</summary>
         [Parameter] public bool Card { get; set; } = false;
+        /// <summary>Raised when the menu is disposed.</summary>
         [Parameter] public EventCallback Disposed { get; set; }
 
         private List<DropdownItem> subMenuItems = new();

--- a/src/TabBlazor/Components/Flags/Flag.razor.cs
+++ b/src/TabBlazor/Components/Flags/Flag.razor.cs
@@ -4,14 +4,23 @@ using System.Drawing;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Renders a country flag. Set <see cref="CountryCode"/> (ISO code) or an explicit <see cref="FlagType"/>.
+    /// </summary>
     public partial class Flag : TablerBaseComponent
     {
         [Inject] public FlagService FlagService { get; set; }
+        /// <summary>The flag size. When null, uses the default size.</summary>
         [Parameter] public FlagSize? Size { get; set; }
+        /// <summary>Rotation in degrees.</summary>
         [Parameter] public int Rotate { get; set; }
+        /// <summary>The flag to render. Resolved from <see cref="CountryCode"/> when not set.</summary>
         [Parameter] public IFlagType FlagType { get; set; }
+        /// <summary>ISO country code used to look up the flag when <see cref="FlagType"/> is not set.</summary>
         [Parameter] public string CountryCode { get; set; }
+        /// <summary>Explicit width (CSS value).</summary>
         [Parameter] public string Width  { get; set; }
+        /// <summary>Explicit height (CSS value).</summary>
         [Parameter] public string Height { get; set; }
 
         protected override void OnParametersSet()

--- a/src/TabBlazor/Components/Forms/AutoComplete/Autocomplete.razor.cs
+++ b/src/TabBlazor/Components/Forms/AutoComplete/Autocomplete.razor.cs
@@ -7,6 +7,11 @@ using Timer = System.Timers.Timer;
 
 namespace TabBlazor;
 
+/// <summary>
+/// A text input with debounced async suggestions. Returns the typed string value (use <c>Typeahead</c> to bind
+/// a selected object). Supply results via <see cref="SearchMethod"/>; suggestions can be grouped and templated.
+/// <typeparamref name="TItem"/> is the suggestion item type.
+/// </summary>
 public partial class Autocomplete<TItem> : TablerBaseComponent, IAsyncDisposable
 {
     [Inject] public TablerService TablerService { get; set; }
@@ -24,30 +29,54 @@ public partial class Autocomplete<TItem> : TablerBaseComponent, IAsyncDisposable
 
     private FieldIdentifier FieldIdentifier { get; set; }
 
+    /// <summary>Additional CSS class(es) for the input.</summary>
     [Parameter] public string CssClass { get; set; }
+    /// <summary>Controls the visual layout (e.g. flush). Defaults to <see cref="DisplayMode.Default"/>.</summary>
     [Parameter] public DisplayMode DisplayMode { get; set; } = DisplayMode.Default;
+    /// <summary>Optional header text shown above the results list.</summary>
     [Parameter] public string ResultHeader { get; set; }
+    /// <summary>Template rendered for each suggestion.</summary>
     [Parameter] public RenderFragment<TItem> ResultTemplate { get; set; }
+    /// <summary>Template shown when no suggestions match.</summary>
     [Parameter] public RenderFragment NotFoundTemplate { get; set; }
+    /// <summary>Raised when the text value changes.</summary>
     [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    /// <summary>Identifies the bound field for validation; set automatically by <c>@bind-Value</c>.</summary>
     [Parameter] public Expression<Func<string>> ValueExpression { get; set; }
+    /// <summary>Raised when the input loses focus.</summary>
     [Parameter] public EventCallback<FocusEventArgs> OnBlur { set; get; }
+    /// <summary>The text value. Supports two-way binding via <c>@bind-Value</c>.</summary>
     [Parameter] public string Value { get; set; }
+    /// <summary>Delay in milliseconds before searching after typing. Defaults to 300.</summary>
     [Parameter] public int Debounce { get; set; } = 300;
+    /// <summary>Optional grouping key for suggestions.</summary>
     [Parameter] public Expression<Func<TItem, object>> GroupBy { get; set; }
+    /// <summary>Projects a grouping key to its header text.</summary>
     [Parameter] public Func<object, string> GroupingHeaderExpression { get; set; }
+    /// <summary>Template for group headers.</summary>
     [Parameter] public RenderFragment<object> GroupingHeaderTemplate { get; set; }
-    
+
+    /// <summary>Async function returning suggestions for the current search text. Required.</summary>
     [Parameter] public Func<string, Task<List<TItem>>> SearchMethod { get; set; }
+    /// <summary>Raised when a suggestion is selected.</summary>
     [Parameter] public EventCallback<TItem> OnItemSelected { get; set; }
+    /// <summary>When set, only the text after the last occurrence of this character is searched (e.g. for tags).</summary>
     [Parameter] public string SeparatorCharacter { get; set; }
+    /// <summary>When true, the input is disabled. Defaults to false.</summary>
     [Parameter] public bool Disabled { get; set; } = false;
+    /// <summary>When true, skips EditContext validation notifications. Defaults to false.</summary>
     [Parameter] public bool DisableValidation { get; set; }
+    /// <summary>When true, shows suggestions as soon as the input is focused. Defaults to false.</summary>
     [Parameter] public bool ShowOptionOnFocus { get; set; }
+    /// <summary>Placeholder text for the input.</summary>
     [Parameter] public string Placeholder { get; set; }
+    /// <summary>Minimum characters before searching. Defaults to 2.</summary>
     [Parameter] public int MinimumLength { get; set; } = 2;
+    /// <summary>Positioning strategy for the suggestions popup. When null, uses the configured default.</summary>
     [Parameter] public Positioning? Positioning { get; set; }
+    /// <summary>Popper placement of the suggestions. Defaults to <see cref="Placement.BottomStart"/>.</summary>
     [Parameter] public Placement Placement { get; set; } = Placement.BottomStart;
+    /// <summary>Popper offset in pixels. Defaults to 2.</summary>
     [Parameter] public int PopperOffset { get; set; } = 2;
 
     private Positioning EffectivePositioning =>

--- a/src/TabBlazor/Components/Forms/Checkboxes/Checkbox.razor.cs
+++ b/src/TabBlazor/Components/Forms/Checkboxes/Checkbox.razor.cs
@@ -3,16 +3,27 @@ using System.Threading.Tasks;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A checkbox input that can also render as a toggle switch. Supports two-way binding via <c>@bind-Value</c>.
+    /// </summary>
     public partial class Checkbox : ComponentBase
     {
+        /// <summary>The label text shown next to the checkbox.</summary>
         [Parameter] public string Label { get; set; }
+        /// <summary>Optional secondary description text shown below the label.</summary>
         [Parameter] public string Description { get; set; }
+        /// <summary>The checked state. Supports two-way binding via <c>@bind-Value</c>.</summary>
         [Parameter] public bool Value { get; set; }
+        /// <summary>Raised when the checked state changes.</summary>
         [Parameter] public EventCallback<bool> ValueChanged { get; set; }
+        /// <summary>Raised after the checked state changes, in addition to <see cref="ValueChanged"/>.</summary>
         [Parameter] public EventCallback Changed { get; set; }
+        /// <summary>When true, the checkbox is disabled. Defaults to false.</summary>
         [Parameter] public bool Disabled { get; set; }
+        /// <summary>When true, renders as a toggle switch instead of a checkbox. Defaults to false.</summary>
         [Parameter] public bool Switch { get; set; }
 
+        /// <summary>Optional content rendered inside a select-group item layout instead of the standard label.</summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         private bool isSelectGroup => ChildContent != null;

--- a/src/TabBlazor/Components/Forms/Checkboxes/CheckboxTriState.razor.cs
+++ b/src/TabBlazor/Components/Forms/Checkboxes/CheckboxTriState.razor.cs
@@ -2,17 +2,27 @@
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A three-state checkbox whose <see cref="Value"/> can be true, false, or null (indeterminate).
+    /// Supports two-way binding via <c>@bind-Value</c>.
+    /// </summary>
     public partial class CheckboxTriState : ComponentBase
     {
         private bool isInitialized;
         [Inject] public TablerService TablerService { get; set; }
+        /// <summary>The label text shown next to the checkbox.</summary>
         [Parameter] public string Label { get; set; }
+        /// <summary>Optional secondary description text shown below the label.</summary>
         [Parameter] public string Description { get; set; }
 
+        /// <summary>The state: true (checked), false (unchecked), or null (indeterminate).</summary>
         [Parameter] public bool? Value { get; set; }
 
+        /// <summary>Raised when the state changes.</summary>
         [Parameter] public EventCallback<bool?> ValueChanged { get; set; }
+        /// <summary>Raised after the state changes, in addition to <see cref="ValueChanged"/>.</summary>
         [Parameter] public EventCallback Changed { get; set; }
+        /// <summary>When true, the checkbox is disabled. Defaults to false.</summary>
         [Parameter] public bool Disabled { get; set; }
 
         protected ElementReference Element { get; set; }

--- a/src/TabBlazor/Components/Forms/Datepickers/Datepicker.razor.cs
+++ b/src/TabBlazor/Components/Forms/Datepickers/Datepicker.razor.cs
@@ -8,14 +8,25 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Calendar-based date picker bound to a <see cref="DateTime"/> or <see cref="DateTimeOffset"/> value
+    /// (or their nullable variants). Renders either inline or inside a dropdown opened from a text input.
+    /// </summary>
     public partial class Datepicker<TValue> : TablerBaseComponent
     {
+        /// <summary>When true, renders the calendar inline instead of inside a dropdown. Defaults to false.</summary>
         [Parameter] public bool Inline { get; set; }
+        /// <summary>The .NET date format string used to display the selected date in the input. Defaults to "d" (short date).</summary>
         [Parameter] public string Format { get; set; } = "d";
+        /// <summary>The currently selected date. <typeparamref name="TValue"/> must be <see cref="DateTime"/> or <see cref="DateTimeOffset"/> (or nullable).</summary>
         [Parameter] public TValue SelectedDate { get; set; }
+        /// <summary>Invoked when the selected date changes; enables two-way binding via @bind-SelectedDate.</summary>
         [Parameter] public EventCallback<TValue> SelectedDateChanged { get; set; }
+        /// <summary>Expression identifying the bound field, used for validation inside an <see cref="EditContext"/>.</summary>
         [Parameter] public Expression<Func<TValue>> SelectedDateExpression { get; set; }
+        /// <summary>Optional label rendered above the picker.</summary>
         [Parameter] public string Label { get; set; }
+        /// <summary>Controls how the input is styled. Defaults to <see cref="DisplayMode.Default"/>.</summary>
         [Parameter] public DisplayMode DisplayMode { get; set; } = DisplayMode.Default;
         [CascadingParameter] private EditContext CascadedEditContext { get; set; }
 

--- a/src/TabBlazor/Components/Forms/Selects/Select.razor.cs
+++ b/src/TabBlazor/Components/Forms/Selects/Select.razor.cs
@@ -6,18 +6,34 @@ using TabBlazor.Components.Selects;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A native single-select dropdown bound to a list of items, with optional clearing and custom text/value
+    /// projection. <typeparamref name="TItem"/> is the source item type; <typeparamref name="TValue"/> is the
+    /// selected value type. When the two differ, supply <see cref="ConvertExpression"/>.
+    /// </summary>
     public partial class Select<TItem, TValue> : TablerBaseComponent
     {
+        /// <summary>The items shown in the dropdown.</summary>
         [Parameter] public List<TItem> Items { get; set; }
+        /// <summary>The currently selected value. Supports two-way binding via <c>@bind-SelectedValue</c>.</summary>
         [Parameter] public TValue SelectedValue { get; set; }
+        /// <summary>Raised when the selected value changes.</summary>
         [Parameter] public EventCallback<TValue> SelectedValueChanged { get; set; }
+        /// <summary>Raised after a selection change, in addition to <see cref="SelectedValueChanged"/>.</summary>
         [Parameter] public EventCallback Updated { get; set; }
+        /// <summary>Projects an item to its display text. Defaults to <c>item.ToString()</c> when not set.</summary>
         [Parameter] public Func<TItem, string> TextExpression { get; set; }
+        /// <summary>Projects an item to its bound value. Required when <typeparamref name="TItem"/> and <typeparamref name="TValue"/> differ.</summary>
         [Parameter] public Func<TItem, TValue> ConvertExpression { get; set; }
+        /// <summary>Determines whether a given item is rendered as disabled (non-selectable).</summary>
         [Parameter] public Func<TItem, bool> DisabledExpression { get; set; }
+        /// <summary>Text shown when <see cref="Items"/> is empty. Defaults to <c>"*No items*"</c>.</summary>
         [Parameter] public string ItemListEmptyText { get; set; } = "*No items*";
+        /// <summary>Placeholder shown when nothing is selected. Defaults to <c>"*Select*"</c>.</summary>
         [Parameter] public string NoSelectedText { get; set; } = "*Select*";
+        /// <summary>When true, shows a clear button to reset the selection. Defaults to false.</summary>
         [Parameter] public bool Clearable { get; set; }
+        /// <summary>Controls the visual layout (e.g. flush). Defaults to <see cref="DisplayMode.Default"/>.</summary>
         [Parameter] public DisplayMode DisplayMode { get; set; } = DisplayMode.Default;
 
         protected List<ListItem<TItem, TValue>> itemList = new();

--- a/src/TabBlazor/Components/Forms/TablerForm.razor.cs
+++ b/src/TabBlazor/Components/Forms/TablerForm.razor.cs
@@ -12,26 +12,73 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Form container that wraps a model in an <see cref="EditContext"/> and runs validation through a pluggable <see cref="IFormValidator"/>.
+    /// Place inputs and a submit control inside it to build a validated form.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="Model"/> is null nothing is rendered except the child content; the form activates once a model is supplied.
+    /// Uses the DI-registered <see cref="IFormValidator"/> (DataAnnotations by default) unless <see cref="Validator"/> is set explicitly.
+    /// </remarks>
     public partial class TablerForm : ComponentBase
     {
         [Inject] protected IServiceProvider Provider { get; set; }
 
+        /// <summary>
+        /// Captures any unmatched HTML attributes and forwards them to the underlying form element.
+        /// </summary>
         [Parameter(CaptureUnmatchedValues = true)]
         public IDictionary<string, object> UnknownParameters { get; set; }
 
+        /// <summary>
+        /// The model object the form edits and validates. The form renders only when this is non-null.
+        /// </summary>
         [Parameter] public object Model { get; set; }
+
+        /// <summary>
+        /// The form content, typically input components and a submit button.
+        /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// The validator used to validate the model. Defaults to the <see cref="IFormValidator"/> registered in DI when not set.
+        /// </summary>
         [Parameter] public IFormValidator Validator { get; set; }
+
+        /// <summary>
+        /// Invoked when the form is submitted and the model is valid; receives the current <see cref="EditContext"/>.
+        /// </summary>
         [Parameter] public EventCallback<EditContext> OnValidSubmit { get; set; }
-        
+
+        /// <summary>
+        /// Whether the model currently passes validation. Bind with <see cref="IsValidChanged"/> to observe validity.
+        /// </summary>
         [Parameter] public bool IsValid { get; set; }
+
+        /// <summary>
+        /// Raised when <see cref="IsValid"/> changes, enabling two-way binding of the validity state.
+        /// </summary>
         [Parameter] public EventCallback<bool> IsValidChanged { get; set; }
-        
+
+        /// <summary>
+        /// The dynamically instantiated validator component instance used during validation.
+        /// </summary>
         public DynamicComponent ValidatorInstance { get; set; }
 
+        /// <summary>
+        /// Indicates whether the model has been modified. Always returns <c>true</c>.
+        /// </summary>
         public bool IsModified => true;
         protected EditContext EditContext { get; set; }
+
+        /// <summary>
+        /// Whether the form (and its <see cref="EditContext"/>) is currently rendered; <c>true</c> only when a model is set.
+        /// </summary>
         public bool RenderForm { get; set; }
+
+        /// <summary>
+        /// Whether submission is allowed, i.e. the model is both valid and modified.
+        /// </summary>
         public bool CanSubmit => IsValid && IsModified;
 
         private bool initialized;

--- a/src/TabBlazor/Components/Forms/Typeaheads/Typeahead.razor.cs
+++ b/src/TabBlazor/Components/Forms/Typeaheads/Typeahead.razor.cs
@@ -11,26 +11,50 @@ using Timer = System.Timers.Timer;
 
 namespace TabBlazor;
 
+/// <summary>
+/// A search-as-you-type selector that binds a chosen value. Unlike <c>Autocomplete</c>, it returns a strongly
+/// typed selection. <typeparamref name="TItem"/> is the suggestion type; <typeparamref name="TValue"/> is the
+/// bound value type — supply <see cref="ConvertExpression"/> when they differ.
+/// </summary>
 public partial class Typeahead<TItem, TValue> : TablerBaseComponent, IDisposable
 {
+    /// <summary>Async function returning suggestions for the search text. Required.</summary>
     [Parameter] public Func<string, Task<IEnumerable<TItem>>> SearchMethod { get; set; }
+    /// <summary>The selected value. Supports two-way binding via <c>@bind-SelectedValue</c>.</summary>
     [Parameter] public TValue SelectedValue { get; set; }
+    /// <summary>Raised when the selected value changes.</summary>
     [Parameter] public EventCallback<TValue> SelectedValueChanged { get; set; }
+    /// <summary>Identifies the bound field for validation; set automatically by <c>@bind-SelectedValue</c>.</summary>
     [Parameter] public Expression<Func<TValue>> SelectedValueExpression { get; set; }
+    /// <summary>Raised after the selection changes.</summary>
     [Parameter] public EventCallback Changed { get; set; }
+    /// <summary>Delay in milliseconds before searching after typing. Defaults to 300.</summary>
     [Parameter] public int Debounce { get; set; } = 300;
+    /// <summary>Minimum characters before searching. Defaults to 3.</summary>
     [Parameter] public int MinimumLength { get; set; } = 3;
+    /// <summary>Maximum number of suggestions shown. Defaults to 20.</summary>
     [Parameter] public int MaximumItems { get; set; } = 20;
+    /// <summary>Placeholder text for the search box.</summary>
     [Parameter] public string SearchPlaceholderText { get; set; } = "";
+    /// <summary>Template rendered for each suggestion.</summary>
     [Parameter] public RenderFragment<TItem> ListTemplate { get; set; }
+    /// <summary>Projects a suggestion item to its bound value. Required when <typeparamref name="TItem"/> and <typeparamref name="TValue"/> differ.</summary>
     [Parameter] public Func<TItem, TValue> ConvertExpression { get; set; }
+    /// <summary>Projects a suggestion item to a unique id.</summary>
     [Parameter] public Func<TItem, string> IdExpression { get; set; }
+    /// <summary>Optional max height (CSS) of the suggestions list.</summary>
     [Parameter] public string MaxListHeight { get; set; }
+    /// <summary>Optional width (CSS) of the suggestions list.</summary>
     [Parameter] public string ListWidth { get; set; }
+    /// <summary>Projects the selected value to its display text.</summary>
     [Parameter] public Func<TValue, string> SelectedTextExpression { get; set; }
+    /// <summary>When true, shows suggestions as soon as the input is focused. Defaults to false.</summary>
     [Parameter] public bool ShowOptionOnFocus { get; set; }
+    /// <summary>Controls the visual layout (e.g. flush). Defaults to <see cref="DisplayMode.Default"/>.</summary>
     [Parameter] public DisplayMode DisplayMode { get; set; } = DisplayMode.Default;
+    /// <summary>Positioning strategy for the suggestions popup. When null, uses the configured default.</summary>
     [Parameter] public Positioning? Positioning { get; set; }
+    /// <summary>Popper placement of the suggestions. Defaults to <see cref="Placement.BottomStart"/>.</summary>
     [Parameter] public Placement Placement { get; set; } = Placement.BottomStart;
 
     [CascadingParameter] private EditContext CascadedEditContext { get; set; }

--- a/src/TabBlazor/Components/Forms/ValueInputs/ValueInput.razor.cs
+++ b/src/TabBlazor/Components/Forms/ValueInputs/ValueInput.razor.cs
@@ -6,6 +6,11 @@ using System.Linq.Expressions;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A generic text-backed input that parses and binds to a strongly typed <typeparamref name="TValue"/>,
+    /// integrating with an ambient <see cref="EditContext"/> for validation. Reports a parse failure as a
+    /// validation message instead of throwing.
+    /// </summary>
     public partial class ValueInput<TValue> : TablerBaseComponent, IDisposable
     {
         private string currentValue;
@@ -13,15 +18,22 @@ namespace TabBlazor
         private string FieldCssClasses;
         private ValidationMessageStore validationMessageStore;
 
+        /// <summary>The bound value. Supports two-way binding via <c>@bind-Value</c>.</summary>
         [Parameter] public TValue Value { get; set; }
+        /// <summary>Raised when a successfully parsed value changes.</summary>
         [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
+        /// <summary>Identifies the bound field for validation; set automatically by <c>@bind-Value</c>.</summary>
         [Parameter] public Expression<Func<TValue>> ValueExpression { get; set; }
+        /// <summary>The label text shown for the input.</summary>
         [Parameter] public string Label { get; set; }
+        /// <summary>Controls the visual layout (e.g. flush). Defaults to <see cref="DisplayMode.Default"/>.</summary>
         [Parameter] public DisplayMode DisplayMode { get; set; } = DisplayMode.Default;
+        /// <summary>Validation message shown when the entered text cannot be parsed to <typeparamref name="TValue"/>.</summary>
         [Parameter] public string ParsingErrorMessage { get; set; }
 
         [CascadingParameter] private EditContext CascadedEditContext { get; set; }
 
+        /// <summary>True when the current input parsed successfully to <typeparamref name="TValue"/>.</summary>
         public bool IsValid { get; set; } = true;
 
         private string CurrentValue

--- a/src/TabBlazor/Components/Icons/Icon.razor.cs
+++ b/src/TabBlazor/Components/Icons/Icon.razor.cs
@@ -3,16 +3,29 @@ using System.Collections.Generic;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Renders an SVG icon. Set <see cref="IconType"/> to one of the generated icon types. Size, color,
+    /// stroke, rotation and animation are configurable.
+    /// </summary>
     public partial class Icon : TablerBaseComponent
     {
+        /// <summary>Explicit color (CSS value). When empty, uses <see cref="TablerBaseComponent.TextColor"/>.</summary>
         [Parameter] public string Color { get; set; }
+        /// <summary>Icon size in pixels. Defaults to 24.</summary>
         [Parameter] public int Size { get; set; } = 24;
+        /// <summary>SVG stroke width. Falls back to the icon's own width, then 2.</summary>
         [Parameter] public double? StrokeWidth { get; set; }
+        /// <summary>The icon to render.</summary>
         [Parameter] public IIconType IconType { get; set; }
+        /// <summary>Whether to render the filled variant, when available.</summary>
         [Parameter] public bool? Filled { get; set; }
+        /// <summary>Rotation in degrees.</summary>
         [Parameter] public int Rotate { get; set; }
+        /// <summary>Accessible title / tooltip text for the icon.</summary>
         [Parameter] public string Title { get; set; }
+        /// <summary>Additional CSS class(es) applied to the icon.</summary>
         [Parameter] public string CssClass { get; set; }
+        /// <summary>Optional animation (pulse, tada, rotate).</summary>
         [Parameter] public IconAnimation Animation { get; set; }
 
 

--- a/src/TabBlazor/Components/Layouts/Row.razor.cs
+++ b/src/TabBlazor/Components/Layouts/Row.razor.cs
@@ -2,8 +2,10 @@
 
 namespace TabBlazor
 {
+    /// <summary>A Bootstrap grid row container for <see cref="RowCol"/> columns.</summary>
     public partial class Row : TablerBaseComponent
     {
+        /// <summary>When true, adds card gutters between columns. Defaults to false.</summary>
         [Parameter] public bool HasCards { get; set; }
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Layouts/RowCol.razor.cs
+++ b/src/TabBlazor/Components/Layouts/RowCol.razor.cs
@@ -2,15 +2,24 @@
 
 namespace TabBlazor
 {
+    /// <summary>A Bootstrap grid column inside a <see cref="Row"/>, with per-breakpoint width settings.</summary>
     public partial class RowCol : TablerBaseComponent
     {
+        /// <summary>Column span at all sizes (1–12). 0 means unset.</summary>
         [Parameter] public int Columns { get; set; } = 0;
+        /// <summary>Column span at the xs breakpoint. 0 means unset.</summary>
         [Parameter] public int Xs { get; set; } = 0;
+        /// <summary>Column span at the sm breakpoint. 0 means unset.</summary>
         [Parameter] public int Sm { get; set; } = 0;
+        /// <summary>Column span at the md breakpoint. 0 means unset.</summary>
         [Parameter] public int Md { get; set; } = 0;
+        /// <summary>Column span at the lg breakpoint. 0 means unset.</summary>
         [Parameter] public int Lg { get; set; } = 0;
+        /// <summary>Column span at the xl breakpoint. 0 means unset.</summary>
         [Parameter] public int Xl { get; set; } = 0;
+        /// <summary>Column span at the xxl breakpoint. 0 means unset.</summary>
         [Parameter] public int XXl { get; set; } = 0;
+        /// <summary>When true, the column sizes to its content (<c>col-auto</c>). Defaults to false.</summary>
         [Parameter] public bool Auto { get; set; }
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Modals/ModalView.razor.cs
+++ b/src/TabBlazor/Components/Modals/ModalView.razor.cs
@@ -6,14 +6,22 @@ using TabBlazor.Services;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Renders a single open modal's chrome (header, body, sizing, dragging). Created internally by
+    /// <see cref="IModalService"/>; you usually don't place this directly.
+    /// </summary>
     public partial class ModalView : ComponentBase, IDisposable
     {
 
         [Inject] protected TablerService TablerService { get; set; }
         [Inject] private IModalService ModalService { get; set; }
+        /// <summary>The modal title.</summary>
         [Parameter] public string Title { get; set; }
+        /// <summary>The modal appearance/behavior options (size, draggable, close triggers, etc.).</summary>
         [Parameter] public ModalOptions Options { get; set; }
+        /// <summary>The modal body content.</summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+        /// <summary>Raised when the modal is closed.</summary>
         [Parameter] public EventCallback OnClosed { get; set; }
 
         public string HeaderCssClass { get; private set; }

--- a/src/TabBlazor/Components/Modals/Services/IModalService.cs
+++ b/src/TabBlazor/Components/Modals/Services/IModalService.cs
@@ -6,19 +6,40 @@ using TabBlazor.Components.Modals;
 
 namespace TabBlazor.Services
 {
+    /// <summary>
+    /// Service for showing modals and dialogs. Registered by <c>AddTabBlazor</c>; inject it and call
+    /// <see cref="ShowAsync{TComponent}"/> to display a component as a modal, awaiting the user's result.
+    /// </summary>
     public interface IModalService
     {
+        /// <summary>Raised when the set of open modals changes.</summary>
         event Action OnChanged;
+        /// <summary>The currently open modals.</summary>
         IEnumerable<ModalModel> Modals { get; }
+        /// <summary>
+        /// Shows <typeparamref name="TComponent"/> as a modal and awaits its result. Use
+        /// <see cref="RenderComponent{T}"/> to pass parameters; close from within via <see cref="Close(ModalResult)"/>.
+        /// </summary>
+        /// <param name="title">The modal title.</param>
+        /// <param name="component">The component (with parameters) to render inside the modal.</param>
+        /// <param name="modalOptions">Optional appearance/behavior options.</param>
+        /// <returns>The result, including whether it was cancelled and any returned data.</returns>
         Task<ModalResult> ShowAsync<TComponent>(string title, RenderComponent<TComponent> component, ModalOptions modalOptions = null) where TComponent : IComponent;
+        /// <summary>Closes the top-most modal with the given result.</summary>
         void Close(ModalResult modalResult);
+        /// <summary>Closes the top-most modal as cancelled.</summary>
         void Close();
+        /// <summary>Shows a simple confirm/alert dialog and returns whether the user confirmed.</summary>
         Task<bool> ShowDialogAsync(DialogOptions options);
 
+        /// <summary>Updates the title of the top-most modal.</summary>
         void UpdateTitle(string title);
+        /// <summary>Forces open modals to re-render.</summary>
         void Refresh();
 
+        /// <summary>Registers a <see cref="ModalView"/> host. Called internally by the component.</summary>
         ModalViewSettings RegisterModalView(ModalView modalView);
+        /// <summary>Unregisters a <see cref="ModalView"/> host. Called internally by the component.</summary>
         void UnRegisterModalView(ModalView modalView);
         //int AddZIndex();
         //int DeductZIndex();

--- a/src/TabBlazor/Components/Modals/Standard/DialogModal.razor.cs
+++ b/src/TabBlazor/Components/Modals/Standard/DialogModal.razor.cs
@@ -3,10 +3,14 @@ using TabBlazor.Services;
 
 namespace TabBlazor.Components.Modals
 {
+    /// <summary>
+    /// The built-in confirm/alert dialog shown by <see cref="Services.IModalService.ShowDialogAsync"/>.
+    /// </summary>
     public partial class DialogModal : ComponentBase
     {
         [Inject] private IModalService modalService { get; set; }
 
+        /// <summary>The dialog content and button configuration.</summary>
         [Parameter] public DialogOptions Options { get; set; }
         private void Cancel()
         {

--- a/src/TabBlazor/Components/Navbars/Navbar.razor.cs
+++ b/src/TabBlazor/Components/Navbars/Navbar.razor.cs
@@ -2,14 +2,23 @@
 
 namespace TabBlazor;
 
+/// <summary>
+/// A responsive navigation bar hosting <see cref="NavbarMenuItem"/> entries, supporting horizontal or vertical
+/// layout and collapsing below a configurable breakpoint.
+/// </summary>
 public partial class Navbar : TablerBaseComponent, IDisposable
 {
     private readonly List<NavbarMenuItem> navbarItems = new();
     [Inject] private NavigationManager navigationManager { get; set; }
+    /// <summary>The navbar background style (dark, light, transparent).</summary>
     [Parameter] public NavbarBackground Background { get; set; }
+    /// <summary>Horizontal or vertical layout.</summary>
     [Parameter] public NavbarDirection Direction { get; set; }
+    /// <summary>Whether the navbar starts expanded. Defaults to true.</summary>
     [Parameter] public bool IsExpanded { get; set; } = true;
+    /// <summary>The breakpoint below which the navbar collapses. Defaults to <see cref="PageBreakpoint.Sm"/>.</summary>
     [Parameter] public PageBreakpoint CollapseAt { get; set; } = PageBreakpoint.Sm;
+    /// <summary>How active links are matched against the current URL.</summary>
     [Parameter] public NavLinkMatch? NavLinkMatch { get; set; }
 
     protected string HtmlTag => "div";

--- a/src/TabBlazor/Components/Navbars/NavbarMenuItem.razor.cs
+++ b/src/TabBlazor/Components/Navbars/NavbarMenuItem.razor.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace TabBlazor
 {
+    /// <summary>An item within a <see cref="Navbar"/>, optionally a link and/or a container for a sub-menu.</summary>
     public partial class NavbarMenuItem : TablerBaseComponent, IDisposable
     {
         [CascadingParameter(Name = "Navbar")] Navbar Navbar { get; set; }
@@ -11,11 +12,17 @@ namespace TabBlazor
 
         [Inject] private NavigationManager NavigationManager { get; set; }
 
+        /// <summary>The navigation URL. When set, the item renders as a link.</summary>
         [Parameter] public string Href { get; set; }
+        /// <summary>The item label text.</summary>
         [Parameter] public string Text { get; set; }
+        /// <summary>Optional icon content shown before the text.</summary>
         [Parameter] public RenderFragment MenuItemIcon { get; set; }
+        /// <summary>Optional nested sub-menu content.</summary>
         [Parameter] public RenderFragment SubMenu { get; set; }
+        /// <summary>Whether the sub-menu starts expanded. Defaults to false.</summary>
         [Parameter] public bool Expanded { get; set; }
+        /// <summary>When true, a sub-menu can be expanded/collapsed. Defaults to true.</summary>
         [Parameter] public bool Expandable { get; set; } = true;
 
         public bool IsTopMenuItem => ParentMenuItem == null;

--- a/src/TabBlazor/Components/Navigation/Navigation.razor.cs
+++ b/src/TabBlazor/Components/Navigation/Navigation.razor.cs
@@ -2,12 +2,16 @@
 
 namespace TabBlazor
 {
+    /// <summary>The root container for a tree of <see cref="NavigationItem"/> entries (e.g. a sidebar menu).</summary>
     public partial class Navigation : NavigationBase
     {
+        /// <summary>When true, renders bordered navigation styling. Defaults to false.</summary>
         [Parameter] public bool Bordered { get; set; }
 
+        /// <summary>Raised when a navigation item is clicked.</summary>
         [Parameter] public EventCallback<NavigationItem> OnItemClicked { get; set; }
 
+        /// <summary>When true, clicking an item expands its sub-menu rather than navigating. Defaults to false.</summary>
         [Parameter] public bool ExpandOnClick { get; set; }
 
       

--- a/src/TabBlazor/Components/Navigation/NavigationBase.cs
+++ b/src/TabBlazor/Components/Navigation/NavigationBase.cs
@@ -6,8 +6,13 @@ using System.Threading.Tasks;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Base class for <see cref="Navigation"/> and <see cref="NavigationItem"/>, managing the parent/child tree,
+    /// expansion and active state.
+    /// </summary>
     public abstract class NavigationBase : TablerBaseComponent, IDisposable
     {
+        /// <summary>The parent node in the navigation tree, supplied via cascading parameter.</summary>
         [CascadingParameter] public NavigationBase Parent { get; set; }
 
 

--- a/src/TabBlazor/Components/Navigation/NavigationItem.razor.cs
+++ b/src/TabBlazor/Components/Navigation/NavigationItem.razor.cs
@@ -2,14 +2,19 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace TabBlazor
 {
+    /// <summary>An entry within a <see cref="Navigation"/>, optionally containing a nested sub-menu.</summary>
     public partial class NavigationItem : NavigationBase
     {
 
+        /// <summary>The item label text.</summary>
         [Parameter] public string Title { get; set; }
-     
+
+        /// <summary>Optional icon content shown before the title.</summary>
         [Parameter] public RenderFragment MenuIcon { get; set; }
+        /// <summary>Optional nested sub-menu content.</summary>
         [Parameter] public RenderFragment SubMenu { get; set; }
 
+        /// <summary>Arbitrary data associated with the item.</summary>
         [Parameter] public object Data { get; set; }
 
 

--- a/src/TabBlazor/Components/ObjectBrowser/ObjectBrowser.razor.cs
+++ b/src/TabBlazor/Components/ObjectBrowser/ObjectBrowser.razor.cs
@@ -9,9 +9,14 @@ using TabBlazor.Services;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A diagnostic component that reflects over an object (or collection) and renders its properties in a table,
+    /// drilling into nested objects via modals. Useful for debugging/inspection.
+    /// </summary>
     public partial class ObjectBrowser
     {
         [Inject] public IModalService ModalService { get; set; }
+        /// <summary>The object or collection to inspect.</summary>
         [Parameter] public object Object { get; set; }
 
         private Type objectType;

--- a/src/TabBlazor/Components/ObjectBrowser/PropertyValueLink.razor.cs
+++ b/src/TabBlazor/Components/ObjectBrowser/PropertyValueLink.razor.cs
@@ -9,11 +9,14 @@ using TabBlazor.Services;
 
 namespace TabBlazor.Components.ObjectBrowser
 {
+    /// <summary>Renders a clickable value that opens an <see cref="TabBlazor.ObjectBrowser"/> on the value when clicked.</summary>
     public partial class PropertyValueLink
     {
         [Inject] public IModalService ModalService { get; set; }
+        /// <summary>The value to inspect when the link is clicked.</summary>
         [Parameter] public object PropertyValue { get; set; }
 
+        /// <summary>The link content to display.</summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         private async Task ObjectDetails()

--- a/src/TabBlazor/Components/Pages/PageMainTitle.razor.cs
+++ b/src/TabBlazor/Components/Pages/PageMainTitle.razor.cs
@@ -2,8 +2,10 @@
 
 namespace TabBlazor
 {
+    /// <summary>The main page heading, styled per Tabler page conventions.</summary>
     public partial class PageMainTitle : TablerBaseComponent
     {
+        /// <summary>The HTML heading element to render. Defaults to <c>"h1"</c>.</summary>
         [Parameter] public string HtmlTag { get; set; } = "h1";
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Progresses/Progress.razor.cs
+++ b/src/TabBlazor/Components/Progresses/Progress.razor.cs
@@ -5,19 +5,29 @@ using Microsoft.AspNetCore.Components.Rendering;
 namespace TabBlazor
 {
 
+    /// <summary>The height of a <see cref="Progress"/> bar.</summary>
     public enum ProgressSize
     {
+        /// <summary>Standard height.</summary>
         Default,
+        /// <summary>Thin bar.</summary>
         Small,
+        /// <summary>Thick bar.</summary>
         Large
     }
 
+    /// <summary>A progress bar supporting a fixed percentage or an indeterminate animation.</summary>
     public partial class Progress : TablerBaseComponent
     {
+        /// <summary>The fill color of the bar.</summary>
         [Parameter] public TablerColor Color { get; set; }
+        /// <summary>The bar height. Defaults to <see cref="ProgressSize.Default"/>.</summary>
         [Parameter] public ProgressSize Size { get; set; }
+        /// <summary>When true, shows an indeterminate animation instead of a fixed value. Defaults to false.</summary>
         [Parameter] public bool Indeterminate { get; set; }
+        /// <summary>The fill percentage (0–100).</summary>
         [Parameter] public int Percentage { get; set; }
+        /// <summary>Optional text shown on the bar.</summary>
         [Parameter] public string Text { get; set; }
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/QuickTables/Columns/PropertyColumn.cs
+++ b/src/TabBlazor/Components/QuickTables/Columns/PropertyColumn.cs
@@ -1,12 +1,19 @@
 namespace TabBlazor.Components.QuickTables;
 
+/// <summary>
+/// A <see cref="QuickTable{TGridItem}"/> column bound to a property of the row via an expression. Derives the
+/// cell text, default title and sort order from <see cref="Property"/>. <typeparamref name="TProp"/> is the
+/// property type.
+/// </summary>
 public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>, ISortBuilderColumn<TGridItem>
 {
     private Func<TGridItem, string> _cellTextFunc;
     private Expression<Func<TGridItem, TProp>> _lastAssignedProperty;
     private GridSort<TGridItem> _sortBuilder;
 
+    /// <summary>The property expression to display and sort by, e.g. <c>@(p => p.Name)</c>. Required.</summary>
     [Parameter] [EditorRequired] public Expression<Func<TGridItem, TProp>> Property { get; set; } = default!;
+    /// <summary>Optional format string applied when the property type implements <see cref="IFormattable"/>.</summary>
     [Parameter] public string Format { get; set; }
 
     GridSort<TGridItem> ISortBuilderColumn<TGridItem>.SortBuilder => _sortBuilder;

--- a/src/TabBlazor/Components/QuickTables/Columns/TemplateColumn.cs
+++ b/src/TabBlazor/Components/QuickTables/Columns/TemplateColumn.cs
@@ -1,11 +1,17 @@
 namespace TabBlazor.Components.QuickTables;
 
+/// <summary>
+/// A <see cref="QuickTable{TGridItem}"/> column that renders arbitrary content per row via a template, rather
+/// than a single bound property. Sortable only when <see cref="SortBy"/> is supplied.
+/// </summary>
 public class TemplateColumn<TGridItem> : ColumnBase<TGridItem>, ISortBuilderColumn<TGridItem>
 {
     private static readonly RenderFragment<TGridItem> EmptyChildContent = _ => builder => { };
 
+    /// <summary>The template rendered for each row, receiving the row item as context.</summary>
     [Parameter] public RenderFragment<TGridItem> ChildContent { get; set; } = EmptyChildContent;
 
+    /// <summary>Optional sort definition; when set, the column becomes sortable.</summary>
     [Parameter] public GridSort<TGridItem> SortBy { get; set; }
 
     GridSort<TGridItem> ISortBuilderColumn<TGridItem>.SortBuilder => SortBy;

--- a/src/TabBlazor/Components/QuickTables/QuickTable.razor.cs
+++ b/src/TabBlazor/Components/QuickTables/QuickTable.razor.cs
@@ -3,6 +3,12 @@ using TabBlazor.Components.QuickTables.Infrastructure;
 
 namespace TabBlazor.Components.QuickTables;
 
+/// <summary>
+/// A high-performance data grid with optional virtualization, sorting, pagination and resizable columns.
+/// Supply data through either <see cref="Items"/> (an <see cref="IQueryable{T}"/>) or <see cref="ItemsProvider"/>
+/// (for server-side / async sources such as EF Core), and define columns with <c>PropertyColumn</c> /
+/// <c>TemplateColumn</c> in <see cref="ChildContent"/>. <typeparamref name="TGridItem"/> is the row type.
+/// </summary>
 [CascadingTypeParameter(nameof(TGridItem))]
 public partial class QuickTable<TGridItem> : IAsyncDisposable
 {
@@ -43,19 +49,31 @@ public partial class QuickTable<TGridItem> : IAsyncDisposable
         columnsFirstCollectedSubscriber.SubscribeOrMove(internalGridContext.ColumnsFirstCollected);
     }
 
+    /// <summary>The data source as an <see cref="IQueryable{T}"/>. Mutually exclusive with <see cref="ItemsProvider"/>.</summary>
     [Parameter] public IQueryable<TGridItem> Items { get; set; }
+    /// <summary>A callback that supplies rows on demand (paging/sorting applied), for async or remote data. Mutually exclusive with <see cref="Items"/>.</summary>
     [Parameter] public GridItemsProvider<TGridItem> ItemsProvider { get; set; }
+    /// <summary>Additional CSS class(es) applied to the table element.</summary>
     [Parameter] public string Class { get; set; }
+    /// <summary>The table theme. Defaults to <c>"default"</c>.</summary>
     [Parameter] public string Theme { get; set; } = "default";
+    /// <summary>Column definitions (<c>PropertyColumn</c>, <c>TemplateColumn</c>) for the grid.</summary>
     [Parameter] public RenderFragment ChildContent { get; set; }
+    /// <summary>When true, rows are virtualized for large data sets. Defaults to false.</summary>
     [Parameter] public bool Virtualize { get; set; }
+    /// <summary>The fixed row height in pixels used when virtualizing. Defaults to 50.</summary>
     [Parameter] public float ItemSize { get; set; } = 50;
+    /// <summary>When true, columns can be resized by dragging. Defaults to false.</summary>
     [Parameter] public bool ResizableColumns { get; set; }
+    /// <summary>Projects a row to a stable key used for diffing. Defaults to the item itself.</summary>
     [Parameter] public Func<TGridItem, object> ItemKey { get; set; } = x => x!;
+    /// <summary>Optional pagination state. When set, the grid pages rather than showing all rows.</summary>
     [Parameter] public PaginationState Pagination { get; set; }
 
     [Inject] private IServiceProvider Services { get; set; } = default!;
+    /// <summary>The column the grid is currently sorted by, or null when unsorted.</summary>
     public ColumnBase<TGridItem> SortByColumn { get; set; }
+    /// <summary>True when the current sort is ascending.</summary>
     public bool SortByAscending { get; set; }
 
     public ValueTask DisposeAsync()
@@ -115,6 +133,9 @@ public partial class QuickTable<TGridItem> : IAsyncDisposable
         collectingColumns = false;
     }
 
+    /// <summary>Sorts the grid by the given column, then refreshes the data.</summary>
+    /// <param name="column">The column to sort by.</param>
+    /// <param name="direction">The direction; <see cref="SortDirection.Auto"/> toggles when re-sorting the same column.</param>
     public Task SortByColumnAsync(ColumnBase<TGridItem> column, SortDirection direction = SortDirection.Auto)
     {
         SortByAscending = direction switch
@@ -131,12 +152,14 @@ public partial class QuickTable<TGridItem> : IAsyncDisposable
         return RefreshDataAsync();
     }
 
+    /// <summary>Opens the display-options popup for the given column.</summary>
     public void ShowColumnOptions(ColumnBase<TGridItem> column)
     {
         displayOptionsForColumn = column;
         StateHasChanged();
     }
 
+    /// <summary>Re-queries the data source and re-renders the grid.</summary>
     public async Task RefreshDataAsync()
     {
         await RefreshDataCoreAsync();

--- a/src/TabBlazor/Components/RangeSliders/RangeSlider.razor.cs
+++ b/src/TabBlazor/Components/RangeSliders/RangeSlider.razor.cs
@@ -5,20 +5,36 @@ using System.Linq;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A range/slider input supporting either a single value or multiple drag points, over a numeric range
+    /// (<see cref="Min"/>/<see cref="Max"/>/<see cref="Step"/>) or a discrete <see cref="Range"/> of values.
+    /// <typeparamref name="TValue"/> is the value type.
+    /// </summary>
     public partial class RangeSlider<TValue> : ComponentBase
     {
+        /// <summary>The single selected value. Supports two-way binding via <c>@bind-Value</c>.</summary>
         [Parameter] public TValue Value { get; set; }
+        /// <summary>Raised when the single value changes.</summary>
         [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
+        /// <summary>The selected values when using multiple drag points. Supports <c>@bind-Values</c>.</summary>
         [Parameter] public List<TValue> Values { get; set; }
+        /// <summary>Raised when the multi-point values change.</summary>
         [Parameter] public EventCallback<List<TValue>> ValuesChanged { get; set; }
+        /// <summary>Discrete set of selectable values. Mutually exclusive with <see cref="Min"/>/<see cref="Max"/>/<see cref="Step"/>.</summary>
         [Parameter] public List<TValue> Range { get; set; }
+        /// <summary>Projects a value to its display label.</summary>
         [Parameter] public Func<TValue, string> LabelExpression { get; set; }
 
+        /// <summary>Minimum value. Defaults to 0. Not used with <see cref="Range"/>.</summary>
         [Parameter] public double Min { get; set; } = 0.0;
+        /// <summary>Maximum value. Defaults to 10. Not used with <see cref="Range"/>.</summary>
         [Parameter] public double Max { get; set; } = 10.0;
+        /// <summary>Step increment. Defaults to 1. Cannot be combined with <see cref="Range"/>.</summary>
         [Parameter] public double Step { get; set; } = 1.0;
 
+        /// <summary>When true, shows min/max labels. Defaults to false.</summary>
         [Parameter] public bool ShowLabels { get; set; } = false;
+        /// <summary>Unmatched HTML attributes applied to the slider input.</summary>
         [Parameter(CaptureUnmatchedValues = true)] public IDictionary<string, object> UnmatchedParameters { get; set; }
 
         private bool SingleDragPoint => Values == null || !Values.Any();

--- a/src/TabBlazor/Components/Statuses/Status.razor.cs
+++ b/src/TabBlazor/Components/Statuses/Status.razor.cs
@@ -3,10 +3,13 @@
 namespace TabBlazor
 {
 
+    /// <summary>A status label/badge with an optional leading dot. Color comes from <see cref="TablerBaseComponent.BackgroundColor"/>.</summary>
     public partial class Status : TablerBaseComponent
     {
+        /// <summary>When true, renders the lighter status style. Defaults to false.</summary>
         [Parameter] public bool Lite { get; set; }
 
+        /// <summary>The leading dot style. Defaults to <see cref="StatusDotType.None"/>.</summary>
         [Parameter] public StatusDotType DotType { get; set; } = StatusDotType.None;
 
 
@@ -24,10 +27,14 @@ namespace TabBlazor
             .ToString();
     }
 
+    /// <summary>The leading dot style for a <see cref="Status"/>.</summary>
     public enum StatusDotType
     {
+        /// <summary>No dot.</summary>
         None = 0,
+        /// <summary>A static dot.</summary>
         Normal = 1,
+        /// <summary>An animated (pulsing) dot.</summary>
         Animate = 2
     }
 

--- a/src/TabBlazor/Components/Statuses/StatusDot.razor.cs
+++ b/src/TabBlazor/Components/Statuses/StatusDot.razor.cs
@@ -3,8 +3,10 @@
 namespace TabBlazor
 {
 
+    /// <summary>A small status dot. Color comes from <see cref="TablerBaseComponent.BackgroundColor"/>.</summary>
     public partial class StatusDot : TablerBaseComponent
     {
+        /// <summary>When true, the dot pulses. Defaults to false.</summary>
         [Parameter] public bool Animate { get; set; }
 
 

--- a/src/TabBlazor/Components/Statuses/StatusIndicator.razor.cs
+++ b/src/TabBlazor/Components/Statuses/StatusIndicator.razor.cs
@@ -3,8 +3,10 @@
 namespace TabBlazor
 {
 
+    /// <summary>A status indicator (pulsing ring). Color comes from <see cref="TablerBaseComponent.BackgroundColor"/>.</summary>
     public partial class StatusIndicator : TablerBaseComponent
     {
+        /// <summary>When true, the indicator animates. Defaults to false.</summary>
         [Parameter] public bool Animate { get; set; }
 
 

--- a/src/TabBlazor/Components/SwitchContent/SwitchContent.razor.cs
+++ b/src/TabBlazor/Components/SwitchContent/SwitchContent.razor.cs
@@ -8,13 +8,21 @@ using System.Threading.Tasks;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Toggles between two content templates with an optional animation, e.g. for an animated icon switch.
+    /// </summary>
     public partial class SwitchContent : TablerBaseComponent
     {
+        /// <summary>Whether the active template is shown. Supports two-way binding via <c>@bind-Active</c>.</summary>
         [Parameter] public bool Active { get; set; }
+        /// <summary>Raised when the active state changes.</summary>
         [Parameter] public EventCallback<bool> ActiveChanged { get; set; }
+        /// <summary>Content shown when not active.</summary>
         [Parameter] public RenderFragment DefaultTemplate { get; set; }
+        /// <summary>Content shown when active.</summary>
         [Parameter] public RenderFragment ActiveTemplate { get; set; }
-        
+
+        /// <summary>The transition animation between templates. Defaults to none.</summary>
         [Parameter] public SwitchAnimation Animation { get; set; }
 
         bool isActive;
@@ -39,15 +47,24 @@ namespace TabBlazor
         }
     }
 
+    /// <summary>The transition animation used by <see cref="SwitchContent"/>.</summary>
     public enum SwitchAnimation
     {
+        /// <summary>No animation.</summary>
         None = 0,
+        /// <summary>Fade between templates.</summary>
         Fade = 1,
+        /// <summary>Flip between templates.</summary>
         Flip = 2,
+        /// <summary>Scale between templates.</summary>
         Scale = 3,
+        /// <summary>Slide up.</summary>
         SlideUp = 4,
+        /// <summary>Slide left.</summary>
         SlideLeft = 5,
+        /// <summary>Slide down.</summary>
         SlideDown = 6,
+        /// <summary>Slide right.</summary>
         SlideRight = 7
     }
 

--- a/src/TabBlazor/Components/TablerBaseComponent.cs
+++ b/src/TabBlazor/Components/TablerBaseComponent.cs
@@ -5,15 +5,40 @@ using Microsoft.Extensions.Options;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Base class for TabBlazor components. Provides common color, content and click parameters,
+    /// HTML attribute passthrough, and CSS class composition via <see cref="ClassBuilder"/>.
+    /// </summary>
     public abstract class TablerBaseComponent : ComponentBase
     {
+        /// <summary>
+        /// Text color applied to the component. Defaults to <see cref="TablerColor.Default"/>.
+        /// </summary>
         [Parameter] public TablerColor TextColor { get; set; } = TablerColor.Default;
+
+        /// <summary>
+        /// Background color applied to the component. Defaults to <see cref="TablerColor.Default"/>.
+        /// </summary>
         [Parameter] public TablerColor BackgroundColor { get; set; } = TablerColor.Default;
+
+        /// <summary>
+        /// Content rendered inside the component.
+        /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Invoked when the component is clicked.
+        /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+        /// <summary>
+        /// Monitors the configured <see cref="TablerOptions"/> for the component.
+        /// </summary>
         [Inject] protected IOptionsMonitor<TablerOptions> Options { get; set; }
 
+        /// <summary>
+        /// Captures any HTML attributes not matched by a declared parameter so they are forwarded to the rendered element.
+        /// </summary>
         [Parameter(CaptureUnmatchedValues = true)]
         public IDictionary<string, object> UnmatchedParameters { get; set; }
 

--- a/src/TabBlazor/Components/Tables/Components/Column.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Column.razor.cs
@@ -9,12 +9,18 @@ using LinqKit;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A column definition for the standard <c>Table</c> component. Bind <see cref="Property"/> for sorting,
+    /// searching and grouping, or supply a <see cref="Template"/> for custom cell content.
+    /// <typeparamref name="Item"/> is the table row type.
+    /// </summary>
     public class ColumnBase<Item> : ComponentBase, IColumn<Item>
     {
         [Inject] protected TableFilterService FilterService { get; set; }
 
         private string _title;
 
+        /// <summary>The column header text. Falls back to the bound <see cref="Property"/> name when not set.</summary>
         [Parameter]
         public string Title
         {
@@ -22,22 +28,39 @@ namespace TabBlazor
             set { _title = value; }
         }
 
+        /// <summary>The owning table, supplied via cascading parameter.</summary>
         [CascadingParameter(Name = "Table")] public ITable<Item> Table { get; set; }
+        /// <summary>Optional fixed column width (CSS value).</summary>
         [Parameter] public string Width { get; set; }
+        /// <summary>When true, the column can be sorted. Requires <see cref="Property"/>. Defaults to false.</summary>
         [Parameter] public bool Sortable { get; set; }
+        /// <summary>When true, the column participates in search. Requires <see cref="Property"/>. Defaults to false.</summary>
         [Parameter] public bool Searchable { get; set; }
+        /// <summary>When true, the table can be grouped by this column. Defaults to false.</summary>
         [Parameter] public bool Groupable { get; set; }
+        /// <summary>Additional CSS class(es) for the column's cells.</summary>
         [Parameter] public string CssClass { get; set; }
+        /// <summary>Whether the column is visible. Defaults to true.</summary>
         [Parameter] public bool Visible { get; set; } = true;
+        /// <summary>When true, marks this as the row-actions column. Defaults to false.</summary>
         [Parameter] public bool ActionColumn { get; set; }
+        /// <summary>Optional custom header content, overriding <see cref="Title"/>.</summary>
         [Parameter] public RenderFragment HeaderTemplate { get; set; }
+        /// <summary>Custom cell content for the row. When omitted, the bound property value is shown.</summary>
         [Parameter] public RenderFragment<Item> Template { get; set; }
+        /// <summary>Custom editor content shown while editing the row.</summary>
         [Parameter] public RenderFragment<Item> EditorTemplate { get; set; }
+        /// <summary>Custom content for the group header row when grouping by this column.</summary>
         [Parameter] public RenderFragment<TableResult<object, Item>> GroupingTemplate { get; set; }
+        /// <summary>The property this column binds to, e.g. <c>@(x => x.Name)</c>. Required for sort/search/group.</summary>
         [Parameter] public Expression<Func<Item, object>> Property { get; set; }
+        /// <summary>Optional custom search predicate, overriding the default contains search.</summary>
         [Parameter] public Expression<Func<Item, string, bool>> SearchExpression { get; set; }
+        /// <summary>Initial sort order for this column, if any.</summary>
         [Parameter] public SortOrder? Sort { get; set; }
+        /// <summary>Cell content alignment.</summary>
         [Parameter] public Align Align { get; set; }
+        /// <summary>When true, the table starts grouped by this column. Defaults to false.</summary>
         [Parameter] public bool Group { get; set; }
 
         public bool SortColumn { get; set; }

--- a/src/TabBlazor/Components/Tables/Components/Table.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Table.razor.cs
@@ -11,6 +11,12 @@ using TabBlazor.Services;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// Base class for the standard <c>Table</c> component: a feature-rich table over a list of
+    /// <typeparamref name="Item"/> with editing (inline or popup), selection, grouping, paging, search and
+    /// detail rows. Define columns in <see cref="ChildContent"/>; wire <see cref="OnItemEdited"/>,
+    /// <see cref="OnItemAdded"/> and <see cref="OnItemDeleted"/> to enable the corresponding actions.
+    /// </summary>
     public class TableBase<Item> : ComponentBase, IPopupEditTable<Item>, ITable<Item>, IInlineEditTable<Item>, IDetailsTable<Item>, ITableRow<Item>, ITableState<Item>
     {
         private Item StateBeforeEdit;
@@ -21,27 +27,47 @@ namespace TabBlazor
         [Inject] private IModalService modalService { get; set; }
         [Inject] private IOptionsMonitor<TablerOptions> tablerOptions { get; set; }
 
+        /// <summary>Unmatched HTML attributes applied to the table element.</summary>
         [Parameter(CaptureUnmatchedValues = true)]
         public IDictionary<string, object> UnknownParameters { get; set; }
 
+        /// <summary>When true, shows the header area above the table. Defaults to true.</summary>
         [Parameter] public bool ShowHeader { get; set; } = true;
+        /// <summary>When true, shows the column header row. Defaults to true.</summary>
         [Parameter] public bool ShowTableHeader { get; set; } = true;
+        /// <summary>When true, rows can be selected. Defaults to false.</summary>
         [Parameter] public bool Selectable { get; set; }
+        /// <summary>When true, shows a label when there are no items. Defaults to true.</summary>
         [Parameter] public bool ShowNoItemsLabel { get; set; } = true;
+        /// <summary>CSS classes for the table element. Defaults to Tabler card-table styling.</summary>
         [Parameter] public string TableClass { get; set; } = "table card-table table-vcenter no-footer";
+        /// <summary>The validation rule set applied while editing. Defaults to <c>"default"</c>.</summary>
         [Parameter] public string ValidationRuleSet { get; set; } = "default";
+        /// <summary>Optional custom content for the table header area.</summary>
         [Parameter] public RenderFragment HeaderTemplate { get; set; }
+        /// <summary>The column definitions for the table.</summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+        /// <summary>Raised when a row is clicked.</summary>
         [Parameter] public EventCallback<Item> OnRowClicked { get; set; }
+        /// <summary>Raised before an item enters edit mode.</summary>
         [Parameter] public EventCallback<Item> OnBeforeEdit { get; set; }
+        /// <summary>Raised when an edited item is saved. Having a handler enables editing.</summary>
         [Parameter] public EventCallback<Item> OnItemEdited { get; set; }
+        /// <summary>Raised when a new item is added. Having a handler enables adding.</summary>
         [Parameter] public EventCallback<Item> OnItemAdded { get; set; }
+        /// <summary>Raised when an item is deleted. Having a handler enables deletion.</summary>
         [Parameter] public EventCallback<Item> OnItemDeleted { get; set; }
+        /// <summary>When true, highlights rows on hover. Defaults to false.</summary>
         [Parameter] public bool Hover { get; set; }
+        /// <summary>When true, wraps the table for horizontal scrolling on small screens. Defaults to false.</summary>
         [Parameter] public bool Responsive { get; set; }
+        /// <summary>Factory used to create a new item when adding; defaults to <c>Activator.CreateInstance</c>.</summary>
         [Parameter] public Func<Task<Item>> AddItemFactory { get; set; }
+        /// <summary>Custom delete confirmation; return false to cancel. Overrides <see cref="ConfirmDelete"/>.</summary>
         [Parameter] public Func<Item, Task<bool>> ConfirmDeleteFunction { get; set; }
+        /// <summary>When true, shows a confirm dialog before deleting. Defaults to true.</summary>
         [Parameter] public bool ConfirmDelete { get; set; } = true;
+        /// <summary>How rows are edited (e.g. inline or popup).</summary>
         [Parameter] public TableEditMode EditMode { get; set; }
 
         [Parameter] public OnCancelStrategy? CancelStrategy { get; set; }

--- a/src/TabBlazor/Components/Tabs/Tab.razor.cs
+++ b/src/TabBlazor/Components/Tabs/Tab.razor.cs
@@ -2,11 +2,15 @@
 
 namespace TabBlazor
 {
+   /// <summary>A single tab page within a <c>Tabs</c> container.</summary>
    public partial class Tab : TablerBaseComponent, ITab
     {
         [CascadingParameter] Tabs ContainerTabSet { get; set; }
+        /// <summary>The tab title. Ignored when <see cref="Header"/> is set.</summary>
         [Parameter] public string Title { get; set; }
+        /// <summary>Optional custom header content, overriding <see cref="Title"/>.</summary>
         [Parameter] public RenderFragment Header { get; set; }
+        /// <summary>Whether this tab is selected initially. Defaults to false.</summary>
         [Parameter] public bool Active { get; set; }
 
         string TitleCssClass => ContainerTabSet.ActiveTab == this ? "active" : null;

--- a/src/TabBlazor/Components/Timelines/Timeline.razor.cs
+++ b/src/TabBlazor/Components/Timelines/Timeline.razor.cs
@@ -2,14 +2,19 @@
 
 namespace TabBlazor
 {
+    /// <summary>The visual style of a <see cref="Timeline"/>.</summary>
     public enum TimelineType
     {
+        /// <summary>Standard timeline.</summary>
         Default,
+        /// <summary>Compact, simplified timeline.</summary>
         Simple
     }
 
+    /// <summary>A vertical list of <see cref="TimelineItem"/> events.</summary>
     public partial class Timeline : TablerBaseComponent
     {
+        /// <summary>The timeline style. Defaults to <see cref="TimelineType.Default"/>.</summary>
         [Parameter] public TimelineType Type { get; set; } = TimelineType.Default;
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Timelines/TimelineItem.razor.cs
+++ b/src/TabBlazor/Components/Timelines/TimelineItem.razor.cs
@@ -2,12 +2,18 @@
 
 namespace TabBlazor
 {
+    /// <summary>A single event within a <see cref="Timeline"/>.</summary>
     public partial class TimelineItem : TablerBaseComponent
     {
+        /// <summary>Short text shown inside the event icon. Ignored when <see cref="IconTemplate"/> is set.</summary>
         [Parameter] public string IconText { get; set; }
+        /// <summary>Optional custom icon content.</summary>
         [Parameter] public RenderFragment IconTemplate { get; set; }
+        /// <summary>The color of the event icon.</summary>
         [Parameter] public TablerColor IconColor { get; set; }
+        /// <summary>The time/date label for the event.</summary>
         [Parameter] public string Time { get; set; }
+        /// <summary>The event title.</summary>
         [Parameter] public string Title { get; set; }
 
         protected override string ClassNames => ClassBuilder

--- a/src/TabBlazor/Components/Toasts/ToastView.razor.cs
+++ b/src/TabBlazor/Components/Toasts/ToastView.razor.cs
@@ -8,9 +8,11 @@ using TabBlazor.Services;
 
 namespace TabBlazor.Components.Toasts
 {
+    /// <summary>Renders a single toast notification, with optional auto-close countdown. Managed by <c>ToastService</c>.</summary>
     public partial class ToastView : IDisposable
     {
         [Inject] ToastService ToastService { get;set;}
+        /// <summary>The toast model to render.</summary>
         [Parameter] public ToastModel Toast { get; set; }
 
         private CountdownTimer _countdownTimer;

--- a/src/TabBlazor/Components/TreeViews/TreeView.razor.cs
+++ b/src/TabBlazor/Components/TreeViews/TreeView.razor.cs
@@ -3,34 +3,58 @@ using TabBlazor.Components.TreeViews;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A hierarchical tree of <typeparamref name="TItem"/> nodes with selection, checkboxes, lazy child
+    /// loading, expansion control and optional drag-and-drop. Provide children via <see cref="ChildSelector"/>
+    /// or <see cref="ChildSelectorAsync"/>.
+    /// </summary>
     public partial class TreeView<TItem> : ComponentBase
     {
+        /// <summary>The root items of the tree.</summary>
         [Parameter] public IList<TItem> Items { get; set; }
+        /// <summary>Async function returning a node's children. Used for lazy loading.</summary>
         [Parameter] public Func<TItem, Task<IList<TItem>>> ChildSelectorAsync { get; set; }
+        /// <summary>Synchronous function returning a node's children.</summary>
         [Parameter] public Func<TItem, IList<TItem>> ChildSelector { get; set; }
+        /// <summary>Template rendered for each node.</summary>
         [Parameter] public RenderFragment<TItem> Template { get; set; }
+        /// <summary>When true, all nodes stay expanded. Defaults to false.</summary>
         [Parameter] public bool AlwaysExpanded { get; set; }
+        /// <summary>Predicate deciding which nodes start expanded.</summary>
         [Parameter] public Func<TItem, bool> DefaultExpanded { get; set; }
+        /// <summary>When true, multiple nodes can be selected. Defaults to false.</summary>
         [Parameter] public bool MultiSelect { get; set; }
+        /// <summary>When true, aligns nodes regardless of expander presence. Defaults to false.</summary>
         [Parameter] public bool AlignTreeNodes { get; set; }
 
+        /// <summary>The selected node (single-select). Supports <c>@bind-SelectedItem</c>.</summary>
         [Parameter] public TItem SelectedItem { get; set; }
+        /// <summary>Raised when the single selection changes.</summary>
         [Parameter] public EventCallback<TItem> SelectedItemChanged { get; set; }
 
+        /// <summary>The selected nodes (multi-select). Supports <c>@bind-SelectedItems</c>.</summary>
         [Parameter] public List<TItem> SelectedItems { get; set; }
+        /// <summary>Raised when the multi-selection changes.</summary>
         [Parameter] public EventCallback<List<TItem>> SelectedItemsChanged { get; set; }
 
+        /// <summary>The checked nodes. Supports <c>@bind-CheckedItems</c>.</summary>
         [Parameter] public List<TItem> CheckedItems { get; set; }
+        /// <summary>Raised when the checked set changes.</summary>
         [Parameter] public EventCallback<List<TItem>> CheckedItemsChanged { get; set; }
 
+        /// <summary>How checkboxes behave (e.g. recursive checking of children).</summary>
         [Parameter] public CheckboxMode CheckboxMode { get; set; }
 
+        /// <summary>Raised when the set of expanded nodes changes.</summary>
         [Parameter] public EventCallback<List<TItem>> ExpandedItemsChanged { get; set; }
 
+        /// <summary>Raised when a node drag starts.</summary>
         [Parameter] public EventCallback<TItem> ItemDragged { get; set; }
+        /// <summary>Raised when a node is dropped onto another.</summary>
         [Parameter] public EventCallback<ItemDropped<TItem>> ItemDropped { get; set; }
 
-        [Parameter] public bool EnableDragAndDrop { get; set; } 
+        /// <summary>When true, nodes can be reordered via drag-and-drop. Defaults to false.</summary>
+        [Parameter] public bool EnableDragAndDrop { get; set; }
 
         protected bool isExpanded = false;
         private List<TItem> selectedItems = new List<TItem>();
@@ -97,11 +121,13 @@ namespace TabBlazor
             }
         }
 
+        /// <summary>Expands every node in the tree.</summary>
         public async Task ExpandAllAsync()
         {
             await ExpandAllAsync(Items);
         }
 
+        /// <summary>Collapses every node in the tree.</summary>
         public void CollapseAll()
         {
             expandedItems.Clear();
@@ -160,21 +186,25 @@ namespace TabBlazor
             }
         }
 
+        /// <summary>Returns whether the given node is selected.</summary>
         public bool IsSelected(TItem item)
         {
             return selectedItems.Contains(item);
         }
 
+        /// <summary>Returns whether the given node is checked.</summary>
         public bool? IsChecked(TItem item)
         {
             return checkedItems.Contains(item);
         }
 
+        /// <summary>Returns whether the given node is expanded.</summary>
         public bool IsExpanded(TItem item)
         {
             return expandedItems.Contains(item);
         }
 
+        /// <summary>Toggles the expanded state of the given node.</summary>
         public async void ToggleExpandedAsync(TItem item)
         {
             if (IsExpanded(item))
@@ -192,6 +222,7 @@ namespace TabBlazor
             }
         }
 
+        /// <summary>Toggles the checked state of the given node (and children when recursive).</summary>
         public async Task ToggleCheckedAsync(TItem item)
         {
             if (IsChecked(item) == true)
@@ -218,6 +249,7 @@ namespace TabBlazor
         }
 
 
+        /// <summary>Toggles the selection of the given node, respecting <see cref="MultiSelect"/>.</summary>
         public async Task ToogleSelectedAsync(TItem item)
         {
             bool removed = false;

--- a/src/TabBlazor/Components/TreeViews/TreeViewNodes.razor.cs
+++ b/src/TabBlazor/Components/TreeViews/TreeViewNodes.razor.cs
@@ -10,15 +10,21 @@ using System.Xml.Linq;
 
 namespace TabBlazor.Components.TreeViews
 {
+    /// <summary>Renders one level of nodes within a <see cref="TreeView{TItem}"/>. Used internally and recursively.</summary>
     public partial class TreeViewNodes<TItem> : ComponentBase
     {
         [CascadingParameter(Name = "Root")] private TreeView<TItem> Root { get; set; }
+        /// <summary>The nodes to render at this level.</summary>
         [Parameter] public IList<TItem> Items { get; set; }
+        /// <summary>Function returning a node's children.</summary>
         [Parameter] public Func<TItem, Task<IList<TItem>>> ChildSelectorAsync { get; set; } = node => null;
+        /// <summary>Template rendered for each node.</summary>
         [Parameter] public RenderFragment<TItem> Template { get; set; }
 
+        /// <summary>The nesting depth of this level (0 = root).</summary>
         [Parameter] public int Level { get; set; }
 
+        /// <summary>When true, nodes at this level accept drops. Defaults to false.</summary>
         [Parameter] public bool AllowDrop { get; set; }
 
         private bool CheckAllowDrop(TItem item)

--- a/src/TabBlazor/Components/Utilities/ContentViewer/ContentViewer.razor.cs
+++ b/src/TabBlazor/Components/Utilities/ContentViewer/ContentViewer.razor.cs
@@ -1,10 +1,16 @@
 namespace TabBlazor
 {
+    /// <summary>
+    /// Displays in-memory byte content (e.g. an image or PDF) by creating a browser object URL for it.
+    /// </summary>
     public partial class ContentViewer : TablerBaseComponent, IAsyncDisposable
     {
         [Inject] Services.TablerService TablerService { get; set; }
+        /// <summary>The MIME type of <see cref="Content"/> (e.g. <c>image/png</c>, <c>application/pdf</c>).</summary>
         [Parameter] public string ContentType { get; set; }
+        /// <summary>The raw content bytes to display.</summary>
         [Parameter] public byte[] Content { get; set; }
+        /// <summary>Optional suffix appended to the generated object URL.</summary>
         [Parameter] public string UrlSuffix { get; set; }
 
         private string objectURL;

--- a/src/TabBlazor/Components/Utilities/RenderComponent.cs
+++ b/src/TabBlazor/Components/Utilities/RenderComponent.cs
@@ -5,11 +5,19 @@ using System.Reflection;
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// A fluent builder describing <typeparamref name="TComponent"/> and its parameters, used to pass a component
+    /// into APIs like <see cref="Services.IModalService.ShowAsync{TComponent}"/>. Chain <see cref="Set"/> calls to
+    /// supply parameters, e.g. <c>new RenderComponent&lt;MyComp&gt;().Set(c => c.Value, x)</c>.
+    /// </summary>
     public class RenderComponent<TComponent> where TComponent : IComponent
     {
         private static readonly Type TComponentType = typeof(TComponent);
         private readonly Dictionary<string, object> parameters = new(StringComparer.Ordinal);
 
+        /// <summary>Sets a <c>[Parameter]</c> (or <c>[CascadingParameter]</c>) on the component and returns this builder for chaining.</summary>
+        /// <param name="parameterSelector">Selects the target parameter property, e.g. <c>c => c.Title</c>.</param>
+        /// <param name="value">The value to assign. Must not be null.</param>
         public RenderComponent<TComponent> Set<TValue>(Expression<Func<TComponent, TValue>> parameterSelector, TValue value)
         {
             if (value is null)
@@ -42,6 +50,7 @@ namespace TabBlazor
             return propertyInfo.Name;
         }
 
+        /// <summary>The render fragment that instantiates the component with the configured parameters.</summary>
         public RenderFragment Contents
         {
             get

--- a/src/TabBlazor/TabBlazor.csproj
+++ b/src/TabBlazor/TabBlazor.csproj
@@ -13,13 +13,23 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryType>git</RepositoryType>
 		<PackageIcon>TabBlazorLogo.png</PackageIcon>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
-	<!--<PropertyGroup>
+	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	</PropertyGroup>-->
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<DebugType>portable</DebugType>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<Content Remove="compilerconfig.json" />
@@ -30,6 +40,8 @@
 			<Pack>True</Pack>
 			<PackagePath></PackagePath>
 		</None>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<None Include="AGENTS.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 

--- a/src/TabBlazor/TablerColor.cs
+++ b/src/TabBlazor/TablerColor.cs
@@ -2,8 +2,13 @@
 
 namespace TabBlazor
 {
+    /// <summary>
+    /// The Tabler color palette used throughout the library for backgrounds, text, borders and component
+    /// accents. Combine with <see cref="ColorsExtensions.GetColorClass"/> to produce CSS classes.
+    /// </summary>
     public enum TablerColor
     {
+        /// <summary>No explicit color; inherits the component's default styling.</summary>
         Default,
         Blue,
         //BlueLight, 
@@ -32,15 +37,32 @@ namespace TabBlazor
         Dark
     }
 
+    /// <summary>
+    /// The visual style variant applied to a <see cref="TablerColor"/>.
+    /// </summary>
     public enum ColorType
     {
+        /// <summary>Solid filled color.</summary>
         Default,
+        /// <summary>Outlined: colored border and text, transparent background.</summary>
         Outline,
+        /// <summary>Ghost: colored text only, no border or background until hovered.</summary>
         Ghost
     }
 
+    /// <summary>
+    /// Extension methods for turning a <see cref="TablerColor"/> into Tabler/Bootstrap CSS class names.
+    /// </summary>
     public static class ColorsExtensions
     {
+        /// <summary>
+        /// Builds a CSS class for the given color, e.g. <c>btn-primary</c> or <c>bg-blue-lt</c>.
+        /// </summary>
+        /// <param name="color">The color to render. <see cref="TablerColor.Default"/> yields no color suffix.</param>
+        /// <param name="type">The class prefix, e.g. <c>btn</c>, <c>bg</c>, <c>text</c>.</param>
+        /// <param name="colorType">The variant (solid, outline, ghost).</param>
+        /// <param name="suffix">Optional trailing modifier appended to the class.</param>
+        /// <returns>The composed CSS class, or an empty string when <paramref name="color"/> is <see cref="TablerColor.Default"/>.</returns>
         public static string GetColorClass(this TablerColor color, string type,
             ColorType colorType = ColorType.Default, string suffix = "")
         {


### PR DESCRIPTION
Enable documentation generation, Source Link, symbol packages and a packaged README/AGENTS.md so the published NuGet ships a populated TabBlazor.xml. AI agents and IntelliSense can then read component and parameter documentation directly from the package.

Document the public component surface (forms, tables, modals, navigation, dashboards and more) with XML doc comments on types and [Parameter] properties.