### PR TITLE
Add column ShowIn for edit-only and view-only columns

### DIFF
--- a/docs/Tabler.Docs/Components/Tables/TablesEdit.razor
+++ b/docs/Tabler.Docs/Components/Tables/TablesEdit.razor
@@ -30,6 +30,11 @@
                 <Select Items="EnumHelper.GetList<OrderType>()" @bind-SelectedValue="@context.OrderType" TextExpression="e=> e.ToString()" ValueExpression="e=> e" Clearable />
             </EditorTemplate>
         </Column>
+        <Column Item="Order" Title="Discount %" ShowIn="ColumnVisibility.EditOnly">
+            <EditorTemplate>
+                <input type="number" class="form-control" @bind-value="@context.DiscountPercentage" />
+            </EditorTemplate>
+        </Column>
     </ChildContent>
 
 </Table>

--- a/src/TabBlazor/Components/Tables/ColumnVisibility.cs
+++ b/src/TabBlazor/Components/Tables/ColumnVisibility.cs
@@ -1,0 +1,15 @@
+namespace TabBlazor
+{
+    /// <summary>
+    /// Controls where a table <c>Column</c> is shown: in the grid, in the edit form, or both.
+    /// </summary>
+    public enum ColumnVisibility
+    {
+        /// <summary>Shown both as a grid column and in the edit form. This is the default.</summary>
+        ViewAndEdit = 0,
+        /// <summary>Shown only as a grid column; omitted from the edit form.</summary>
+        ViewOnly = 1,
+        /// <summary>Shown only in the edit form (popup edit); omitted from the grid. Not supported in inline edit mode.</summary>
+        EditOnly = 2
+    }
+}

--- a/src/TabBlazor/Components/Tables/Components/Column.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Column.razor.cs
@@ -42,6 +42,12 @@ namespace TabBlazor
         [Parameter] public string CssClass { get; set; }
         /// <summary>Whether the column is visible. Defaults to true.</summary>
         [Parameter] public bool Visible { get; set; } = true;
+        /// <summary>
+        /// Controls where the column appears: in the grid, in the edit form, or both. Defaults to
+        /// <see cref="ColumnVisibility.ViewAndEdit"/>. <see cref="ColumnVisibility.EditOnly"/> is supported in
+        /// popup edit mode only.
+        /// </summary>
+        [Parameter] public ColumnVisibility ShowIn { get; set; } = ColumnVisibility.ViewAndEdit;
         /// <summary>When true, marks this as the row-actions column. Defaults to false.</summary>
         [Parameter] public bool ActionColumn { get; set; }
         /// <summary>Optional custom header content, overriding <see cref="Title"/>.</summary>

--- a/src/TabBlazor/Components/Tables/Components/PopupEdit.razor
+++ b/src/TabBlazor/Components/Tables/Components/PopupEdit.razor
@@ -5,7 +5,7 @@
 
     <ModalView Title="@popupOptions.Title" Options="@popupOptions.ModalOptions" OnClosed=CancelEdit >
         <Dimmer Active="@(Table.ShowSavingDimmer && Table.IsSaving)">
-            @foreach (var column in Table.VisibleColumns)
+            @foreach (var column in Table.EditColumns)
             {
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">@column.Title</label>

--- a/src/TabBlazor/Components/Tables/Components/Table.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Table.razor.cs
@@ -84,7 +84,8 @@ namespace TabBlazor
         [Parameter] public Action<TableEditPopupOptions<Item>> EditPopupMutator { get; set; }
         public bool IsRowValid { get; set; }
         public List<IColumn<Item>> Columns { get; } = new();
-        public List<IColumn<Item>> VisibleColumns => Columns.Where(x => x.Visible).ToList();
+        public List<IColumn<Item>> VisibleColumns => Columns.Where(x => x.Visible && x.ShowIn != ColumnVisibility.EditOnly).ToList();
+        public List<IColumn<Item>> EditColumns => Columns.Where(x => x.ShowIn != ColumnVisibility.ViewOnly && (x.Visible || x.ShowIn == ColumnVisibility.EditOnly)).ToList();
         public bool IsAddInProgress { get; set; }
         public Item CurrentEditItem { get; private set; }
 

--- a/src/TabBlazor/Components/Tables/IColumn.cs
+++ b/src/TabBlazor/Components/Tables/IColumn.cs
@@ -16,6 +16,7 @@ namespace TabBlazor.Components.Tables
         bool Searchable { get; set; }
         bool Groupable { get; set; }
         bool Visible { get; set; }
+        ColumnVisibility ShowIn { get; set; }
         bool SortDescending { get; }
         bool GroupBy { get; set; }
         Align Align { get; set; }

--- a/src/TabBlazor/Components/Tables/ITable.cs
+++ b/src/TabBlazor/Components/Tables/ITable.cs
@@ -68,6 +68,7 @@ namespace TabBlazor.Components.Tables
     {
         List<IColumn<TItem>> Columns { get; }
         List<IColumn<TItem>> VisibleColumns { get; }
+        List<IColumn<TItem>> EditColumns { get; }
 
         bool ShowCheckboxes { get; }
         TItem CurrentEditItem { get; }


### PR DESCRIPTION
Closes #57

## Problem
A table `Column` could only be shown everywhere or nowhere (via `Visible`). There was no way to surface a field in the **popup edit form** without also adding it as a grid column — the ask in #57.

## Change
- New enum `ColumnVisibility { ViewAndEdit, ViewOnly, EditOnly }` and a `Column` parameter `ShowIn` (default `ViewAndEdit`).
- `TableBase.VisibleColumns` (grid + inline + colspan) now excludes `EditOnly`.
- New `TableBase.EditColumns` (used by `PopupEdit`) includes `EditOnly` and excludes `ViewOnly`.
- `IColumn.ShowIn` and `IPopupEditTable.EditColumns` added.

## Scope: popup edit only
`EditOnly` is supported in **popup** edit mode. Inline edit reuses the grid `<tr>`, so an edit-only column has no cell to occupy; it is simply not rendered in inline mode (no exception). Documented on the enum.

An earlier draft threw an `InvalidOperationException` when `EditOnly` was used outside popup mode, but a throwing guard in `OnParametersSet` crashes on a runtime `EditMode` toggle (the new cascading value reaches a still-mounted column before it is removed). Replaced with graceful degradation.

## Demo
`TablesEdit.razor` gains an `EditOnly` "Discount %" field — visible in the popup editor, absent from the grid.

## Verification
- Full solution build: 0 errors (only the pre-existing BL0007 warning).
- Tests: 3 passed.