### PR TITLE
Close dropdown context menu on outside click

### DIFF
--- a/src/TabBlazor/Components/Dropdowns/Dropdown.razor
+++ b/src/TabBlazor/Components/Dropdowns/Dropdown.razor
@@ -1,6 +1,6 @@
 @inherits TablerBaseComponent
 @namespace TabBlazor
-<ClickOutside OnClickOutside="OnClickOutside">
+<ClickOutside OnClickOutside="OnClickOutside" Active="isExpanded">
     <CascadingValue Name=Dropdown Value=this>
     <HtmlElement Tag="@(Direction==DropdownDirection.Down ? "div": "span")"
                  class="@ClassNames"

--- a/src/TabBlazor/Components/Utilities/ClickOutside/ClickOutside.razor.cs
+++ b/src/TabBlazor/Components/Utilities/ClickOutside/ClickOutside.razor.cs
@@ -26,6 +26,15 @@ public partial class ClickOutside
     public ConcurrenceStrategy Concurrence { get; set; } = ConcurrenceStrategy.One;
 
     /// <summary>
+    /// When set, the handler is registered while <c>true</c> and removed while <c>false</c>, regardless of
+    /// <see cref="Strategy"/>. Use this to detect outside clicks for content that is shown programmatically
+    /// (e.g. a context menu) rather than after the wrapped element is clicked. When null (default), registration
+    /// follows <see cref="Strategy"/>.
+    /// </summary>
+    [Parameter]
+    public bool? Active { get; set; }
+
+    /// <summary>
     /// Additional HTML attributes applied to the wrapping element.
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
@@ -71,9 +80,30 @@ public partial class ClickOutside
         await OnClickOutside.InvokeAsync();
     }
 
+    private bool? lastActive;
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
+
+        if (Active.HasValue)
+        {
+            if (Active != lastActive)
+            {
+                lastActive = Active;
+                if (Active.Value)
+                {
+                    await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, false, DotNetObjectReference.Create(this));
+                }
+                else
+                {
+                    await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.removeEvent", Id);
+                }
+            }
+
+            return;
+        }
+
         if (firstRender && Strategy == RegisterStrategy.OnRender)
         {
             await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, Concurrence == ConcurrenceStrategy.One, DotNetObjectReference.Create(this));
@@ -93,7 +123,7 @@ public partial class ClickOutside
 
     private async Task AddClickOutsideHandler()
     {
-        if (Strategy == RegisterStrategy.OnClick)
+        if (!Active.HasValue && Strategy == RegisterStrategy.OnClick)
         {
             await JSRuntime.InvokeVoidAsync("tabBlazor.clickOutsideHandler.addEvent", Id, Concurrence == ConcurrenceStrategy.One, DotNetObjectReference.Create(this));
         }


### PR DESCRIPTION
Closes #88

## Problem
A `Dropdown` opened as a context menu (`OpenAsContextMenu`) did not close when left-clicking outside it.

`Dropdown` wraps its content in `<ClickOutside>`, but `ClickOutside` defaulted to `RegisterStrategy.OnClick` — it armed the JS document click-listener only when the **wrapped element was clicked**. A context menu opens from a right-click on another element, so the trigger is never left-clicked, the listener is never registered, and outside clicks do nothing. The same gap affected the programmatic `Open()` path.

## Change
- **`ClickOutside`**: new `bool? Active` parameter. When set, the listener is registered while `true` and removed while `false` (reactively in `OnAfterRenderAsync`), independent of `Strategy`. When null (default), behavior is unchanged, so other consumers (Navigation, Autocomplete, Offcanvas, Modals) are unaffected. The click-based registration path is suppressed when `Active` is set, to avoid double-arming.
- **`Dropdown.razor`**: `Active="isExpanded"`, so the outside-click listener is armed whenever the menu is open — regardless of how it opened (trigger click, `Open()`, or `OpenAsContextMenu`) — and removed on close.

Because the listener is added after the opening click finishes propagating, it cannot self-close on open.

## Verification
- Full solution build: 0 errors (only the pre-existing BL0007 warning).
- Tests: 3 passed.
- Manual: the `DropdownsContext` demo — right-click to open, left-click outside now closes it; normal dropdowns and item clicks still close.