### PR TITLE
Add unit tests for components and bUnit infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,15 @@ jobs:
         run: dotnet build TabBlazor.slnx --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --no-build --configuration Release --no-restore --verbosity normal
+        run: dotnet test --no-build --configuration Release --no-restore --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: ./coverage/**/coverage.cobertura.xml
+          if-no-files-found: ignore
 
       - name: Publish WASM docs
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,10 +75,22 @@ Tabler CSS framework. Custom styles in `src/TabBlazor/wwwroot/css/tabblazor.scss
 - `TabBlazor.Tests/` — xUnit tests
 - `Icons/IconGenerator/` — Tool to generate icon components
 
+## Testing
+
+xUnit + [bUnit](https://bunit.dev/) (Blazor component rendering) in `TabBlazor.Tests/`.
+
+- **Pure logic** (ClassBuilder, EnumHelper, PredicateBuilder, services): plain xUnit, no render.
+- **Component render tests**: inherit `TabBlazorTestContext` (base `BunitContext` that calls `AddTabBlazor()` and sets loose JS interop). Live under `Components/`, mirroring `src/TabBlazor/Components/` layout.
+- **`Render<T>(...)`, not `RenderComponent<T>`** — TabBlazor has its own `RenderComponent<T>` type that clashes with bUnit's method name.
+- **Naming**: `Method_does_x_when_y` (e.g. `Adds_disabled_class_when_disabled`). One test file per component/class.
+- Coverage collected in CI via `coverlet.collector` (informational artifact, not a gate).
+
+**When adding or editing a component, add or update its tests** in the same change: cover the rendered element, CSS classes from parameters, `ChildContent`, and any `EventCallback`. Components requiring JS interop (inject `IJSRuntime`/`TablerService`/`IPopperService`) or an impractical cascading/generic parent may be left untested — note this in the PR.
+
 ## CI/CD
 
-- PRs: build + test (`ci-pr.yml`, windows-2022 runner)
-- Master push: build + test + publish docs to GitHub Pages (`ci.yml`)
+- PRs + master push: build + test with coverage (`ci.yml`, ubuntu-latest)
+- Master push also publishes docs to GitHub Pages
 - Releases: manual workflow packs + pushes to NuGet (`create-release.yml`)
 
 ## Commit Messages

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
     <PackageVersion Include="ColorCode.HTML" Version="2.0.15" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />

--- a/TabBlazor.Tests/ClassBuilderTests.cs
+++ b/TabBlazor.Tests/ClassBuilderTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+namespace TabBlazor.Tests
+{
+    public class ClassBuilderTests
+    {
+        [Fact]
+        public void Add_splits_and_deduplicates_class_names()
+        {
+            var result = new ClassBuilder("btn btn primary").ToString();
+            Assert.Equal("btn primary", result);
+        }
+
+        [Fact]
+        public void Add_ignores_null_and_whitespace()
+        {
+            var result = new ClassBuilder().Add(null).Add("   ").Add("btn").ToString();
+            Assert.Equal("btn", result);
+        }
+
+        [Fact]
+        public void AddIf_adds_only_when_condition_true()
+        {
+            Assert.Equal("a b", new ClassBuilder("a").AddIf("b", true).ToString());
+            Assert.Equal("a", new ClassBuilder("a").AddIf("b", false).ToString());
+        }
+
+        [Fact]
+        public void AddCompare_adds_class_when_values_match()
+        {
+            Assert.Equal("a active", new ClassBuilder("a").AddCompare("active", 1, 1).ToString());
+            Assert.Equal("a", new ClassBuilder("a").AddCompare("active", 1, 2).ToString());
+        }
+
+        [Fact]
+        public void AddCompare_with_dictionary_adds_matching_entry()
+        {
+            var map = new Dictionary<int, string> { { 1, "one" }, { 2, "two" } };
+            Assert.Equal("two", new ClassBuilder().AddCompare(2, map).ToString());
+        }
+
+        [Fact]
+        public void Remove_is_case_insensitive()
+        {
+            Assert.Equal("b", new ClassBuilder("a b").Remove("A").ToString());
+        }
+
+        [Fact]
+        public void ToString_returns_null_when_empty()
+        {
+            Assert.Null(new ClassBuilder().ToString());
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/AccordionTests.cs
+++ b/TabBlazor.Tests/Components/AccordionTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class AccordionTests : TabBlazorTestContext
+    {
+        private static RenderFragment Item(string title, bool expanded = false) => builder =>
+        {
+            builder.OpenComponent<AccordionItem>(0);
+            builder.AddAttribute(1, nameof(AccordionItem.Title), title);
+            builder.AddAttribute(2, nameof(AccordionItem.Expanded), expanded);
+            builder.AddAttribute(3, nameof(AccordionItem.ChildContent),
+                (RenderFragment)(b => b.AddContent(0, $"{title} body")));
+            builder.CloseComponent();
+        };
+
+        [Fact]
+        public void Renders_div_with_accordion_class()
+        {
+            var cut = Render<Accordion>();
+            Assert.Contains("accordion", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Renders_an_item_per_accordion_item()
+        {
+            var cut = Render<Accordion>(p => p.AddChildContent(b =>
+            {
+                Item("One")(b);
+                Item("Two")(b);
+            }));
+
+            Assert.Equal(2, cut.FindAll("div.accordion-item").Count);
+        }
+
+        [Fact]
+        public void Item_button_collapsed_when_not_expanded()
+        {
+            var cut = Render<Accordion>(p => p.AddChildContent(Item("One")));
+
+            Assert.Contains("collapsed", cut.Find("button.accordion-button").ClassList);
+            Assert.DoesNotContain("show", cut.Find("div.accordion-collapse").ClassList);
+        }
+
+        [Fact]
+        public void Item_shown_when_expanded()
+        {
+            var cut = Render<Accordion>(p => p.AddChildContent(Item("One", expanded: true)));
+
+            Assert.DoesNotContain("collapsed", cut.Find("button.accordion-button").ClassList);
+            Assert.Contains("show", cut.Find("div.accordion-collapse").ClassList);
+        }
+
+        [Fact]
+        public void Clicking_header_expands_item()
+        {
+            var cut = Render<Accordion>(p => p.AddChildContent(Item("One")));
+
+            cut.Find("button.accordion-button").Click();
+
+            Assert.Contains("show", cut.Find("div.accordion-collapse").ClassList);
+        }
+
+        [Fact]
+        public void Opening_one_collapses_other_when_single_open()
+        {
+            var cut = Render<Accordion>(p => p.AddChildContent(b =>
+            {
+                Item("One", expanded: true)(b);
+                Item("Two")(b);
+            }));
+
+            var buttons = cut.FindAll("button.accordion-button");
+            buttons[1].Click();
+
+            var collapses = cut.FindAll("div.accordion-collapse");
+            Assert.DoesNotContain("show", collapses[0].ClassList);
+            Assert.Contains("show", collapses[1].ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/AlertTests.cs
+++ b/TabBlazor.Tests/Components/AlertTests.cs
@@ -1,0 +1,52 @@
+namespace TabBlazor.Tests.Components
+{
+    public class AlertTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_alert_with_title_and_content()
+        {
+            var cut = Render<Alert>(p => p
+                .Add(a => a.Title, "Heads up")
+                .AddChildContent("Body text"));
+
+            Assert.Contains("alert", cut.Find("div").ClassList);
+            Assert.Equal("Heads up", cut.Find("h4.alert-title").TextContent);
+            Assert.Contains("Body text", cut.Markup);
+        }
+
+        [Fact]
+        public void No_title_element_when_title_empty()
+        {
+            var cut = Render<Alert>(p => p.AddChildContent("Body"));
+            Assert.Empty(cut.FindAll("h4.alert-title"));
+        }
+
+        [Fact]
+        public void Dismissible_renders_close_button()
+        {
+            var cut = Render<Alert>(p => p.Add(a => a.Dismissible, true));
+
+            Assert.Contains("alert-dismissible", cut.Find("div").ClassList);
+            Assert.Single(cut.FindAll("button.btn-close"));
+        }
+
+        [Fact]
+        public void Clicking_close_dismisses_alert()
+        {
+            var cut = Render<Alert>(p => p
+                .Add(a => a.Dismissible, true)
+                .AddChildContent("Body"));
+
+            cut.Find("button.btn-close").Click();
+
+            Assert.Empty(cut.FindAll("div.alert"));
+        }
+
+        [Fact]
+        public void Important_adds_important_class()
+        {
+            var cut = Render<Alert>(p => p.Add(a => a.Important, true));
+            Assert.Contains("alert-important", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/AvatarListTests.cs
+++ b/TabBlazor.Tests/Components/AvatarListTests.cs
@@ -1,0 +1,35 @@
+namespace TabBlazor.Tests.Components
+{
+    public class AvatarListTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_avatar_list_class()
+        {
+            var cut = Render<AvatarList>(p => p.AddChildContent("<span>x</span>"));
+
+            var div = cut.Find("div");
+            Assert.Contains("avatar-list", div.ClassList);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<AvatarList>(p => p.AddChildContent("<span>child</span>"));
+            Assert.Equal("child", cut.Find("div span").TextContent);
+        }
+
+        [Fact]
+        public void Adds_stacked_class_when_stacked()
+        {
+            var cut = Render<AvatarList>(p => p.Add(a => a.Stacked, true));
+            Assert.Contains("avatar-list-stacked", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Does_not_add_stacked_class_by_default()
+        {
+            var cut = Render<AvatarList>(p => p.AddChildContent(""));
+            Assert.DoesNotContain("avatar-list-stacked", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/AvatarTests.cs
+++ b/TabBlazor.Tests/Components/AvatarTests.cs
@@ -1,0 +1,54 @@
+namespace TabBlazor.Tests.Components
+{
+    public class AvatarTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_span_with_avatar_class()
+        {
+            var cut = Render<Avatar>(p => p.AddChildContent("AB"));
+
+            var span = cut.Find("span");
+            Assert.Contains("avatar", span.ClassList);
+            Assert.Contains("AB", span.TextContent);
+        }
+
+        [Fact]
+        public void Sets_background_image_style_when_data_provided()
+        {
+            var cut = Render<Avatar>(p => p.Add(a => a.Data, "https://example.com/img.png"));
+
+            var style = cut.Find("span").GetAttribute("style");
+            Assert.Contains("background-image:url('https://example.com/img.png')", style);
+        }
+
+        [Theory]
+        [InlineData(AvatarSize.Small, "avatar-sm")]
+        [InlineData(AvatarSize.Medium, "avatar-md")]
+        [InlineData(AvatarSize.Large, "avatar-lg")]
+        [InlineData(AvatarSize.ExtraLarge, "avatar-xl")]
+        public void Adds_size_class(AvatarSize size, string expected)
+        {
+            var cut = Render<Avatar>(p => p.Add(a => a.Size, size));
+            Assert.Contains(expected, cut.Find("span").ClassList);
+        }
+
+        [Theory]
+        [InlineData(AvatarRounded.Rounded, "rounded")]
+        [InlineData(AvatarRounded.RoundedSmall, "rounded-sm")]
+        [InlineData(AvatarRounded.RoundedLarge, "rounded-lg")]
+        [InlineData(AvatarRounded.Circle, "rounded-circle")]
+        [InlineData(AvatarRounded.None, "rounded-0")]
+        public void Adds_rounded_class(AvatarRounded rounded, string expected)
+        {
+            var cut = Render<Avatar>(p => p.Add(a => a.Rounded, rounded));
+            Assert.Contains(expected, cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<Avatar>(p => p.Add(a => a.BackgroundColor, TablerColor.Primary));
+            Assert.Contains("bg-primary-lt", cut.Find("span").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/BadgeTests.cs
+++ b/TabBlazor.Tests/Components/BadgeTests.cs
@@ -1,0 +1,36 @@
+namespace TabBlazor.Tests.Components
+{
+    public class BadgeTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_span_with_badge_class()
+        {
+            var cut = Render<Badge>(p => p.AddChildContent("5"));
+
+            var span = cut.Find("span");
+            Assert.Contains("badge", span.ClassList);
+            Assert.Contains("5", span.TextContent);
+        }
+
+        [Fact]
+        public void Adds_pill_class_for_pill_shape()
+        {
+            var cut = Render<Badge>(p => p.Add(b => b.Shape, BadgeShape.Pill));
+            Assert.Contains("badge-pill", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Outline_type_adds_outline_class()
+        {
+            var cut = Render<Badge>(p => p.Add(b => b.BadgeType, BadgeType.Outline));
+            Assert.Contains("badge-outline", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Adds_cursor_pointer_when_click_handler_present()
+        {
+            var cut = Render<Badge>(p => p.Add(b => b.OnClick, _ => { }));
+            Assert.Contains("cursor-pointer", cut.Find("span").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/ButtonListTests.cs
+++ b/TabBlazor.Tests/Components/ButtonListTests.cs
@@ -1,0 +1,36 @@
+namespace TabBlazor.Tests.Components
+{
+    public class ButtonListTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_btn_list_class()
+        {
+            var cut = Render<ButtonList>(p => p.AddChildContent("buttons"));
+
+            var div = cut.Find("div");
+            Assert.Contains("btn-list", div.ClassList);
+            Assert.Contains("buttons", div.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<ButtonList>(p => p.AddChildContent("<button>A</button><button>B</button>"));
+            Assert.Equal(2, cut.FindAll("button").Count);
+        }
+
+        [Fact]
+        public void Adds_text_color_class()
+        {
+            var cut = Render<ButtonList>(p => p.Add(x => x.TextColor, TablerColor.Primary));
+            Assert.Contains("text-primary", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<ButtonList>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("div").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/ButtonTests.cs
+++ b/TabBlazor.Tests/Components/ButtonTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class ButtonTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_button_element_with_btn_class()
+        {
+            var cut = Render<Button>(p => p.Add(b => b.Text, "Click"));
+
+            var button = cut.Find("button");
+            Assert.Contains("btn", button.ClassList);
+            Assert.Contains("Click", button.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content_over_text()
+        {
+            var cut = Render<Button>(p => p
+                .Add(b => b.Text, "Ignored")
+                .AddChildContent("<span>Child</span>"));
+
+            Assert.Equal("Child", cut.Find("button").TextContent.Trim());
+        }
+
+        [Fact]
+        public void Adds_disabled_class_when_disabled()
+        {
+            var cut = Render<Button>(p => p.Add(b => b.Disabled, true));
+            Assert.Contains("disabled", cut.Find("button").ClassList);
+        }
+
+        [Theory]
+        [InlineData(ButtonSize.Large, "btn-lg")]
+        [InlineData(ButtonSize.Small, "btn-sm")]
+        public void Adds_size_class(ButtonSize size, string expected)
+        {
+            var cut = Render<Button>(p => p.Add(b => b.Size, size));
+            Assert.Contains(expected, cut.Find("button").ClassList);
+        }
+
+        [Theory]
+        [InlineData(ButtonShape.Pill, "btn-pill")]
+        [InlineData(ButtonShape.Square, "btn-square")]
+        public void Adds_shape_class(ButtonShape shape, string expected)
+        {
+            var cut = Render<Button>(p => p.Add(b => b.Shape, shape));
+            Assert.Contains(expected, cut.Find("button").ClassList);
+        }
+
+        [Fact]
+        public void Renders_anchor_when_type_is_link()
+        {
+            var cut = Render<Button>(p => p
+                .Add(b => b.Type, ButtonType.Link)
+                .Add(b => b.LinkTo, "/home"));
+
+            var anchor = cut.Find("a");
+            Assert.Equal("/home", anchor.GetAttribute("href"));
+        }
+
+        [Fact]
+        public void Invokes_on_click()
+        {
+            var clicked = false;
+            var cut = Render<Button>(p => p
+                .Add(b => b.OnClick, EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, () => clicked = true)));
+
+            cut.Find("button").Click();
+            Assert.True(clicked);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<Button>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("button").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/CardBodyTests.cs
+++ b/TabBlazor.Tests/Components/CardBodyTests.cs
@@ -1,0 +1,28 @@
+namespace TabBlazor.Tests.Components
+{
+    public class CardBodyTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_card_body_class()
+        {
+            var cut = Render<CardBody>(p => p.AddChildContent("Content"));
+
+            var div = cut.Find("div");
+            Assert.Contains("card-body", div.ClassList);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<CardBody>(p => p.AddChildContent("<span>Inner</span>"));
+            Assert.Equal("Inner", cut.Find("span").TextContent);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<CardBody>(p => p.Add(c => c.BackgroundColor, TablerColor.Primary));
+            Assert.Contains("bg-primary", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/CardFooterTests.cs
+++ b/TabBlazor.Tests/Components/CardFooterTests.cs
@@ -1,0 +1,28 @@
+namespace TabBlazor.Tests.Components
+{
+    public class CardFooterTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_card_footer_class()
+        {
+            var cut = Render<CardFooter>(p => p.AddChildContent("Footer"));
+
+            var div = cut.Find("div");
+            Assert.Contains("card-footer", div.ClassList);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<CardFooter>(p => p.AddChildContent("<span>Inner</span>"));
+            Assert.Equal("Inner", cut.Find("span").TextContent);
+        }
+
+        [Fact]
+        public void Adds_text_color_class()
+        {
+            var cut = Render<CardFooter>(p => p.Add(c => c.TextColor, TablerColor.Secondary));
+            Assert.Contains("text-secondary", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/CardHeaderTests.cs
+++ b/TabBlazor.Tests/Components/CardHeaderTests.cs
@@ -1,0 +1,28 @@
+namespace TabBlazor.Tests.Components
+{
+    public class CardHeaderTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_card_header_class()
+        {
+            var cut = Render<CardHeader>(p => p.AddChildContent("Header"));
+
+            var div = cut.Find("div");
+            Assert.Contains("card-header", div.ClassList);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<CardHeader>(p => p.AddChildContent("<span>Inner</span>"));
+            Assert.Equal("Inner", cut.Find("span").TextContent);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<CardHeader>(p => p.Add(c => c.BackgroundColor, TablerColor.Dark));
+            Assert.Contains("bg-dark", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/CardRibbonTests.cs
+++ b/TabBlazor.Tests/Components/CardRibbonTests.cs
@@ -1,0 +1,38 @@
+namespace TabBlazor.Tests.Components
+{
+    public class CardRibbonTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_ribbon_class()
+        {
+            var cut = Render<CardRibbon>(p => p.AddChildContent("New"));
+
+            var div = cut.Find("div");
+            Assert.Contains("ribbon", div.ClassList);
+            Assert.Contains("New", cut.Markup);
+        }
+
+        [Fact]
+        public void Defaults_to_ribbon_right()
+        {
+            var cut = Render<CardRibbon>(p => p.AddChildContent("New"));
+            Assert.Contains("ribbon-right", cut.Find("div").ClassList);
+        }
+
+        [Theory]
+        [InlineData(RibbonPosition.Top, "ribbon-top")]
+        [InlineData(RibbonPosition.Right, "ribbon-right")]
+        public void Adds_position_class(RibbonPosition position, string expected)
+        {
+            var cut = Render<CardRibbon>(p => p.Add(c => c.Position, position));
+            Assert.Contains(expected, cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<CardRibbon>(p => p.Add(c => c.BackgroundColor, TablerColor.Green));
+            Assert.Contains("bg-green", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/CardTabsTests.cs
+++ b/TabBlazor.Tests/Components/CardTabsTests.cs
@@ -1,0 +1,28 @@
+namespace TabBlazor.Tests.Components
+{
+    public class CardTabsTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_card_tabs_class()
+        {
+            var cut = Render<CardTabs>(p => p.AddChildContent("Tabs"));
+
+            var div = cut.Find("div");
+            Assert.Contains("card-tabs", div.ClassList);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<CardTabs>(p => p.AddChildContent("<span>Inner</span>"));
+            Assert.Equal("Inner", cut.Find("span").TextContent);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<CardTabs>(p => p.Add(c => c.BackgroundColor, TablerColor.Primary));
+            Assert.Contains("bg-primary", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/CardTests.cs
+++ b/TabBlazor.Tests/Components/CardTests.cs
@@ -1,0 +1,59 @@
+namespace TabBlazor.Tests.Components
+{
+    public class CardTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_card_class()
+        {
+            var cut = Render<Card>(p => p.AddChildContent("Body"));
+
+            var div = cut.Find("div.card");
+            Assert.Contains("card", div.ClassList);
+            Assert.Contains("Body", cut.Markup);
+        }
+
+        [Fact]
+        public void Renders_anchor_when_link_to_set()
+        {
+            var cut = Render<Card>(p => p.Add(c => c.LinkTo, "/home"));
+
+            var anchor = cut.Find("a");
+            Assert.Equal("/home", anchor.GetAttribute("href"));
+        }
+
+        [Fact]
+        public void Adds_stacked_class_when_stacked()
+        {
+            var cut = Render<Card>(p => p.Add(c => c.Stacked, true));
+            Assert.Contains("card-stacked", cut.Find("div.card").ClassList);
+        }
+
+        [Theory]
+        [InlineData(CardSize.Small, "card-sm")]
+        [InlineData(CardSize.Medium, "card-md")]
+        [InlineData(CardSize.Large, "card-lg")]
+        public void Adds_size_class(CardSize size, string expected)
+        {
+            var cut = Render<Card>(p => p.Add(c => c.Size, size));
+            Assert.Contains(expected, cut.Find("div.card").ClassList);
+        }
+
+        [Fact]
+        public void Renders_top_status_bar_when_status_top_set()
+        {
+            var cut = Render<Card>(p => p.Add(c => c.StatusTop, TablerColor.Primary));
+
+            var status = cut.Find("div.card-status-top");
+            Assert.Contains("bg-primary", status.ClassList);
+        }
+
+        [Fact]
+        public void Renders_start_status_bar_when_status_start_set()
+        {
+            var cut = Render<Card>(p => p.Add(c => c.StatusStart, TablerColor.Danger));
+
+            var status = cut.Find("div.card-status-start");
+            Assert.Contains("bg-danger", status.ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/CardTitleTests.cs
+++ b/TabBlazor.Tests/Components/CardTitleTests.cs
@@ -1,0 +1,33 @@
+namespace TabBlazor.Tests.Components
+{
+    public class CardTitleTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_h1_with_card_title_class_by_default()
+        {
+            var cut = Render<CardTitle>(p => p.AddChildContent("My title"));
+
+            var heading = cut.Find("h1");
+            Assert.Contains("card-title", heading.ClassList);
+            Assert.Equal("My title", heading.TextContent);
+        }
+
+        [Fact]
+        public void Renders_custom_html_tag()
+        {
+            var cut = Render<CardTitle>(p => p
+                .Add(c => c.HtmlTag, "h3")
+                .AddChildContent("Title"));
+
+            var heading = cut.Find("h3");
+            Assert.Contains("card-title", heading.ClassList);
+        }
+
+        [Fact]
+        public void Adds_text_color_class()
+        {
+            var cut = Render<CardTitle>(p => p.Add(c => c.TextColor, TablerColor.Primary));
+            Assert.Contains("text-primary", cut.Find("h1").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/DataGridItemTests.cs
+++ b/TabBlazor.Tests/Components/DataGridItemTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class DataGridItemTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_root_div_with_datagrid_item_class()
+        {
+            var cut = Render<DataGridItem>();
+
+            Assert.NotNull(cut.Find("div.datagrid-item"));
+        }
+
+        [Fact]
+        public void Renders_title_text()
+        {
+            var cut = Render<DataGridItem>(p => p.Add(i => i.Title, "Label"));
+
+            Assert.Contains("Label", cut.Find("div.datagrid-title").TextContent);
+        }
+
+        [Fact]
+        public void Renders_title_template_over_title()
+        {
+            var cut = Render<DataGridItem>(p => p
+                .Add(i => i.Title, "Ignored")
+                .Add(i => i.TitleTemplate, (RenderFragment)(b => b.AddContent(0, "Custom"))));
+
+            var title = cut.Find("div.datagrid-title");
+            Assert.Contains("Custom", title.TextContent);
+            Assert.DoesNotContain("Ignored", title.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content_in_content_section()
+        {
+            var cut = Render<DataGridItem>(p => p.AddChildContent("<span>Value</span>"));
+
+            Assert.Equal("Value", cut.Find("div.datagrid-content").TextContent.Trim());
+        }
+
+        [Fact]
+        public void Adds_text_color_class()
+        {
+            var cut = Render<DataGridItem>(p => p.Add(i => i.TextColor, TablerColor.Danger));
+
+            Assert.Contains("text-danger", cut.Find("div.datagrid-item").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/DataGridTests.cs
+++ b/TabBlazor.Tests/Components/DataGridTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class DataGridTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_root_div_with_datagrid_class()
+        {
+            var cut = Render<DataGrid>();
+
+            var root = cut.Find("div.datagrid");
+            Assert.NotNull(root);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<DataGrid>(p => p.AddChildContent("<span>Body</span>"));
+
+            Assert.Equal("Body", cut.Find("div.datagrid").TextContent.Trim());
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<DataGrid>(p => p.Add(g => g.BackgroundColor, TablerColor.Primary));
+
+            Assert.Contains("bg-primary", cut.Find("div.datagrid").ClassList);
+        }
+
+        [Fact]
+        public void Invokes_on_click()
+        {
+            var clicked = false;
+            var cut = Render<DataGrid>(p => p
+                .Add(g => g.OnClick, EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, () => clicked = true)));
+
+            cut.Find("div.datagrid").Click();
+
+            Assert.True(clicked);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<DataGrid>(p => p.AddUnmatched("data-test", "value"));
+
+            Assert.Equal("value", cut.Find("div.datagrid").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/DetailsRowTests.cs
+++ b/TabBlazor.Tests/Components/DetailsRowTests.cs
@@ -1,0 +1,92 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using TabBlazor.Components.Tables;
+using TabBlazor.Components.Tables.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class DetailsRowTests : TabBlazorTestContext
+    {
+        private sealed class FakeDetailsTable : IDetailsTable<string>
+        {
+            public int VisibleColumnCount { get; set; } = 3;
+            public bool ClearCalled { get; private set; }
+            public RenderFragment<string> DetailsTemplate { get; set; }
+
+            public Task ClearSelectedItem()
+            {
+                ClearCalled = true;
+                return Task.CompletedTask;
+            }
+        }
+
+        private static FakeDetailsTable TableWithTemplate(string content) => new FakeDetailsTable
+        {
+            DetailsTemplate = item => builder => builder.AddContent(0, $"{content}:{item}")
+        };
+
+        [Fact]
+        public void Renders_row_with_details_cell()
+        {
+            var table = TableWithTemplate("body");
+
+            var cut = Render<DetailsRow<string>>(p => p
+                .Add(r => r.Table, table)
+                .Add(r => r.Item, "row1"));
+
+            Assert.NotNull(cut.Find("tr"));
+            Assert.NotNull(cut.Find("td.div-table-details"));
+        }
+
+        [Fact]
+        public void Cell_colspan_matches_visible_column_count()
+        {
+            var table = TableWithTemplate("body");
+            table.VisibleColumnCount = 5;
+
+            var cut = Render<DetailsRow<string>>(p => p
+                .Add(r => r.Table, table)
+                .Add(r => r.Item, "row1"));
+
+            Assert.Equal("5", cut.Find("td.div-table-details").GetAttribute("colspan"));
+        }
+
+        [Fact]
+        public void Renders_details_template_with_item()
+        {
+            var table = TableWithTemplate("body");
+
+            var cut = Render<DetailsRow<string>>(p => p
+                .Add(r => r.Table, table)
+                .Add(r => r.Item, "row1"));
+
+            Assert.Contains("body:row1", cut.Markup);
+        }
+
+        [Fact]
+        public void Renders_close_icon()
+        {
+            var table = TableWithTemplate("body");
+
+            var cut = Render<DetailsRow<string>>(p => p
+                .Add(r => r.Table, table)
+                .Add(r => r.Item, "row1"));
+
+            Assert.Single(cut.FindAll("i.div-table-details-close"));
+        }
+
+        [Fact]
+        public void Clicking_close_clears_selected_item()
+        {
+            var table = TableWithTemplate("body");
+
+            var cut = Render<DetailsRow<string>>(p => p
+                .Add(r => r.Table, table)
+                .Add(r => r.Item, "row1"));
+
+            cut.Find("i.div-table-details-close").Click();
+
+            Assert.True(table.ClearCalled);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/DimmerTests.cs
+++ b/TabBlazor.Tests/Components/DimmerTests.cs
@@ -1,0 +1,55 @@
+namespace TabBlazor.Tests.Components
+{
+    public class DimmerTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_dimmer_wrapper_when_active()
+        {
+            var cut = Render<Dimmer>(p => p
+                .Add(d => d.Active, true)
+                .AddChildContent("<span>content</span>"));
+
+            var div = cut.Find("div.dimmer");
+            Assert.Contains("dimmer", div.ClassList);
+            Assert.Contains("active", div.ClassList);
+        }
+
+        [Fact]
+        public void Renders_only_child_content_when_inactive()
+        {
+            var cut = Render<Dimmer>(p => p
+                .Add(d => d.Active, false)
+                .AddChildContent("<span>content</span>"));
+
+            Assert.Empty(cut.FindAll("div.dimmer"));
+            Assert.Equal("content", cut.Find("span").TextContent);
+        }
+
+        [Fact]
+        public void Renders_spinner_by_default_when_active()
+        {
+            var cut = Render<Dimmer>(p => p.Add(d => d.Active, true));
+            Assert.Single(cut.FindAll("div.loader"));
+        }
+
+        [Fact]
+        public void Hides_spinner_when_show_spinner_false()
+        {
+            var cut = Render<Dimmer>(p => p
+                .Add(d => d.Active, true)
+                .Add(d => d.ShowSpinner, false));
+
+            Assert.Empty(cut.FindAll("div.loader"));
+        }
+
+        [Fact]
+        public void Wraps_child_content_in_dimmer_content_when_active()
+        {
+            var cut = Render<Dimmer>(p => p
+                .Add(d => d.Active, true)
+                .AddChildContent("<span>inner</span>"));
+
+            Assert.Equal("inner", cut.Find("div.dimmer-content span").TextContent);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/IconTests.cs
+++ b/TabBlazor.Tests/Components/IconTests.cs
@@ -1,0 +1,68 @@
+namespace TabBlazor.Tests.Components
+{
+    public class IconTests : TabBlazorTestContext
+    {
+        private static IIconType StrokeIcon => new TablerIcon("<line x1='1' y1='1' x2='2' y2='2' />");
+        private static IIconType FilledIcon => new MDIcon("<path d='M1 1' />");
+
+        [Fact]
+        public void Renders_svg_with_default_size()
+        {
+            var cut = Render<Icon>(p => p.Add(i => i.IconType, StrokeIcon));
+
+            var svg = cut.Find("svg");
+            Assert.Equal("24", svg.GetAttribute("width"));
+            Assert.Equal("24", svg.GetAttribute("height"));
+        }
+
+        [Fact]
+        public void Renders_stroke_variant_for_unfilled_icon()
+        {
+            var cut = Render<Icon>(p => p.Add(i => i.IconType, StrokeIcon));
+
+            var svg = cut.Find("svg");
+            Assert.Equal("none", svg.GetAttribute("fill"));
+            Assert.Equal("currentColor", svg.GetAttribute("stroke"));
+        }
+
+        [Fact]
+        public void Renders_filled_variant_for_filled_icon()
+        {
+            var cut = Render<Icon>(p => p.Add(i => i.IconType, FilledIcon));
+            Assert.Equal("currentColor", cut.Find("svg").GetAttribute("fill"));
+        }
+
+        [Fact]
+        public void Applies_custom_size()
+        {
+            var cut = Render<Icon>(p => p
+                .Add(i => i.IconType, StrokeIcon)
+                .Add(i => i.Size, 32));
+
+            Assert.Equal("32", cut.Find("svg").GetAttribute("width"));
+        }
+
+        [Theory]
+        [InlineData(IconAnimation.Pulse, "icon-pulse")]
+        [InlineData(IconAnimation.Tada, "icon-tada")]
+        [InlineData(IconAnimation.Rotate, "icon-rotate")]
+        public void Adds_animation_class(IconAnimation animation, string expected)
+        {
+            var cut = Render<Icon>(p => p
+                .Add(i => i.IconType, StrokeIcon)
+                .Add(i => i.Animation, animation));
+
+            Assert.Contains(expected, cut.Find("svg").ClassList);
+        }
+
+        [Fact]
+        public void Renders_title_element_when_title_set()
+        {
+            var cut = Render<Icon>(p => p
+                .Add(i => i.IconType, StrokeIcon)
+                .Add(i => i.Title, "Close"));
+
+            Assert.Equal("Close", cut.Find("svg title").TextContent.Trim());
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/InputTests.cs
+++ b/TabBlazor.Tests/Components/InputTests.cs
@@ -1,0 +1,37 @@
+namespace TabBlazor.Tests.Components
+{
+    public class InputTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_input_element()
+        {
+            var cut = Render<Input>();
+
+            Assert.Single(cut.FindAll("input"));
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<Input>(p => p.Add(i => i.BackgroundColor, TablerColor.Blue));
+
+            Assert.Contains("bg-blue", cut.Find("input").ClassList);
+        }
+
+        [Fact]
+        public void Adds_text_color_class()
+        {
+            var cut = Render<Input>(p => p.Add(i => i.TextColor, TablerColor.Red));
+
+            Assert.Contains("text-red", cut.Find("input").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<Input>(p => p.AddUnmatched("placeholder", "type here"));
+
+            Assert.Equal("type here", cut.Find("input").GetAttribute("placeholder"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/NavbarTests.cs
+++ b/TabBlazor.Tests/Components/NavbarTests.cs
@@ -1,0 +1,46 @@
+namespace TabBlazor.Tests.Components
+{
+    public class NavbarTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_navbar_class()
+        {
+            var cut = Render<Navbar>(p => p.AddChildContent("menu"));
+
+            var navbar = cut.Find("div.navbar");
+            Assert.Contains("navbar", navbar.ClassList);
+            Assert.Contains("menu", navbar.TextContent);
+        }
+
+        [Fact]
+        public void Adds_default_expand_class_for_sm_breakpoint()
+        {
+            var cut = Render<Navbar>(p => p.AddChildContent("x"));
+            Assert.Contains("navbar-expand-md", cut.Find("div.navbar").ClassList);
+        }
+
+        [Fact]
+        public void Adds_vertical_class_when_direction_vertical()
+        {
+            var cut = Render<Navbar>(p => p.Add(n => n.Direction, NavbarDirection.Vertical));
+            Assert.Contains("navbar-vertical", cut.Find("div.navbar").ClassList);
+        }
+
+        [Fact]
+        public void Sets_dark_theme_attribute_when_background_dark()
+        {
+            var cut = Render<Navbar>(p => p.Add(n => n.Background, NavbarBackground.Dark));
+
+            var navbar = cut.Find("div.navbar");
+            Assert.Contains("navbar-dark", navbar.ClassList);
+            Assert.Equal("dark", navbar.GetAttribute("data-bs-theme"));
+        }
+
+        [Fact]
+        public void Renders_toggler_button()
+        {
+            var cut = Render<Navbar>(p => p.AddChildContent("x"));
+            Assert.Single(cut.FindAll("button.navbar-toggler"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/NavigationItemTests.cs
+++ b/TabBlazor.Tests/Components/NavigationItemTests.cs
@@ -1,0 +1,53 @@
+namespace TabBlazor.Tests.Components
+{
+    public class NavigationItemTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_list_item_with_nav_item_class()
+        {
+            var cut = Render<NavigationItem>(p => p.Add(n => n.Title, "Home"));
+
+            var li = cut.Find("li");
+            Assert.Contains("nav-item", li.ClassList);
+            Assert.Contains("cursor-pointer", li.ClassList);
+        }
+
+        [Fact]
+        public void Renders_title_in_nav_link_title()
+        {
+            var cut = Render<NavigationItem>(p => p.Add(n => n.Title, "Home"));
+
+            Assert.Equal("Home", cut.Find("span.nav-link-title").TextContent.Trim());
+        }
+
+        [Fact]
+        public void Renders_child_content_over_title()
+        {
+            var cut = Render<NavigationItem>(p => p
+                .Add(n => n.Title, "Ignored")
+                .AddChildContent("<em>Custom</em>"));
+
+            var title = cut.Find("span.nav-link-title");
+            Assert.Contains("Custom", title.TextContent);
+            Assert.DoesNotContain("Ignored", title.TextContent);
+        }
+
+        [Fact]
+        public void Renders_anchor_with_nav_link_class()
+        {
+            var cut = Render<NavigationItem>(p => p.Add(n => n.Title, "Home"));
+
+            Assert.Contains("nav-link", cut.Find("a").ClassList);
+        }
+
+        [Fact]
+        public void Renders_menu_icon_when_provided()
+        {
+            var cut = Render<NavigationItem>(p => p
+                .Add(n => n.Title, "Home")
+                .Add(n => n.MenuIcon, "<i class=\"my-icon\"></i>"));
+
+            Assert.Single(cut.FindAll("span.nav-link-icon i.my-icon"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/PageHeaderTests.cs
+++ b/TabBlazor.Tests/Components/PageHeaderTests.cs
@@ -1,0 +1,36 @@
+namespace TabBlazor.Tests.Components
+{
+    public class PageHeaderTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_page_header_class()
+        {
+            var cut = Render<PageHeader>(p => p.AddChildContent("header"));
+
+            var div = cut.Find("div");
+            Assert.Contains("page-header", div.ClassList);
+            Assert.Contains("header", div.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<PageHeader>(p => p.AddChildContent("<h1>Title</h1>"));
+            Assert.Single(cut.FindAll("h1"));
+        }
+
+        [Fact]
+        public void Adds_text_color_class()
+        {
+            var cut = Render<PageHeader>(p => p.Add(x => x.TextColor, TablerColor.Danger));
+            Assert.Contains("text-danger", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<PageHeader>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("div").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/PageMainTitleTests.cs
+++ b/TabBlazor.Tests/Components/PageMainTitleTests.cs
@@ -1,0 +1,40 @@
+namespace TabBlazor.Tests.Components
+{
+    public class PageMainTitleTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_h1_with_page_title_class_by_default()
+        {
+            var cut = Render<PageMainTitle>(p => p.AddChildContent("Dashboard"));
+
+            var heading = cut.Find("h1");
+            Assert.Contains("page-title", heading.ClassList);
+            Assert.Equal("Dashboard", heading.TextContent);
+        }
+
+        [Fact]
+        public void Renders_custom_html_tag()
+        {
+            var cut = Render<PageMainTitle>(p => p
+                .Add(x => x.HtmlTag, "h2")
+                .AddChildContent("Sub"));
+
+            Assert.Single(cut.FindAll("h2"));
+            Assert.Empty(cut.FindAll("h1"));
+        }
+
+        [Fact]
+        public void Adds_text_color_class()
+        {
+            var cut = Render<PageMainTitle>(p => p.Add(x => x.TextColor, TablerColor.Success));
+            Assert.Contains("text-success", cut.Find("h1").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<PageMainTitle>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("h1").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/PagePretitleTests.cs
+++ b/TabBlazor.Tests/Components/PagePretitleTests.cs
@@ -1,0 +1,36 @@
+namespace TabBlazor.Tests.Components
+{
+    public class PagePretitleTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_page_pretitle_class()
+        {
+            var cut = Render<PagePretitle>(p => p.AddChildContent("Overview"));
+
+            var div = cut.Find("div");
+            Assert.Contains("page-pretitle", div.ClassList);
+            Assert.Equal("Overview", div.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<PagePretitle>(p => p.AddChildContent("<em>note</em>"));
+            Assert.Single(cut.FindAll("em"));
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<PagePretitle>(p => p.Add(x => x.BackgroundColor, TablerColor.Azure));
+            Assert.Contains("bg-azure", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<PagePretitle>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("div").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/PageTests.cs
+++ b/TabBlazor.Tests/Components/PageTests.cs
@@ -1,0 +1,36 @@
+namespace TabBlazor.Tests.Components
+{
+    public class PageTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_page_class()
+        {
+            var cut = Render<Page>(p => p.AddChildContent("body"));
+
+            var div = cut.Find("div");
+            Assert.Contains("page", div.ClassList);
+            Assert.Contains("body", div.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<Page>(p => p.AddChildContent("<section>Inner</section>"));
+            Assert.Single(cut.FindAll("section"));
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<Page>(p => p.Add(x => x.BackgroundColor, TablerColor.Primary));
+            Assert.Contains("bg-primary", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<Page>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("div").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/PaginatorTests.cs
+++ b/TabBlazor.Tests/Components/PaginatorTests.cs
@@ -1,0 +1,31 @@
+using TabBlazor.Components.QuickTables;
+
+namespace TabBlazor.Tests.Components
+{
+    public class PaginatorTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_card_footer()
+        {
+            var cut = Render<Paginator>(p => p.Add(x => x.Value, new PaginationState()));
+
+            Assert.Contains("card-footer", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Hides_pagination_when_total_count_unknown()
+        {
+            var cut = Render<Paginator>(p => p.Add(x => x.Value, new PaginationState()));
+
+            Assert.Empty(cut.FindAll("ul.pagination"));
+        }
+
+        [Fact]
+        public void Footer_is_empty_when_total_count_unknown()
+        {
+            var cut = Render<Paginator>(p => p.Add(x => x.Value, new PaginationState()));
+
+            Assert.Empty(cut.Find("div.card-footer").Children);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/PopoverTests.cs
+++ b/TabBlazor.Tests/Components/PopoverTests.cs
@@ -1,0 +1,52 @@
+namespace TabBlazor.Tests.Components
+{
+    public class PopoverTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_container_with_trigger_content()
+        {
+            var cut = Render<Popover>(p => p.AddChildContent("Open me"));
+
+            var container = cut.Find("div.popover-container");
+            Assert.Contains("Open me", container.TextContent);
+        }
+
+        [Fact]
+        public void Popover_hidden_until_trigger_clicked()
+        {
+            var cut = Render<Popover>(p => p
+                .AddChildContent("Trigger")
+                .Add(x => x.PopoverTemplate, "<em>Details</em>"));
+
+            Assert.Empty(cut.FindAll("span.popover"));
+        }
+
+        [Fact]
+        public void Clicking_trigger_shows_popover_template()
+        {
+            var cut = Render<Popover>(p => p
+                .AddChildContent("Trigger")
+                .Add(x => x.PopoverTemplate, "<em>Details</em>"));
+
+            cut.Find("div.popover-container > span").Click();
+
+            var popover = cut.Find("span.popover");
+            Assert.Contains("Details", popover.TextContent);
+        }
+
+        [Fact]
+        public void Clicking_trigger_twice_hides_popover()
+        {
+            var cut = Render<Popover>(p => p
+                .AddChildContent("Trigger")
+                .Add(x => x.PopoverTemplate, "<em>Details</em>"));
+
+            var trigger = cut.Find("div.popover-container > span");
+            trigger.Click();
+            Assert.Single(cut.FindAll("span.popover"));
+
+            cut.Find("div.popover-container > span").Click();
+            Assert.Empty(cut.FindAll("span.popover"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/ProgressTests.cs
+++ b/TabBlazor.Tests/Components/ProgressTests.cs
@@ -1,0 +1,54 @@
+namespace TabBlazor.Tests.Components
+{
+    public class ProgressTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_progress_with_bar()
+        {
+            var cut = Render<Progress>(p => p.Add(x => x.Percentage, 50));
+
+            Assert.Contains("progress", cut.Find("div.progress").ClassList);
+            Assert.Contains("progress-bar", cut.Find("div.progress-bar").ClassList);
+        }
+
+        [Fact]
+        public void Sets_bar_width_from_percentage()
+        {
+            var cut = Render<Progress>(p => p.Add(x => x.Percentage, 75));
+
+            var bar = cut.Find("div.progress-bar");
+            Assert.Contains("width: 75%", bar.GetAttribute("style"));
+            Assert.Equal("75", bar.GetAttribute("aria-valuenow"));
+        }
+
+        [Theory]
+        [InlineData(ProgressSize.Small, "progress-sm")]
+        [InlineData(ProgressSize.Large, "progress-lg")]
+        public void Adds_size_class(ProgressSize size, string expected)
+        {
+            var cut = Render<Progress>(p => p.Add(x => x.Size, size));
+            Assert.Contains(expected, cut.Find("div.progress").ClassList);
+        }
+
+        [Fact]
+        public void Adds_indeterminate_class_to_bar()
+        {
+            var cut = Render<Progress>(p => p.Add(x => x.Indeterminate, true));
+            Assert.Contains("progress-bar-indeterminate", cut.Find("div.progress-bar").ClassList);
+        }
+
+        [Fact]
+        public void Adds_bar_color_class()
+        {
+            var cut = Render<Progress>(p => p.Add(x => x.Color, TablerColor.Green));
+            Assert.Contains("bg-green", cut.Find("div.progress-bar").ClassList);
+        }
+
+        [Fact]
+        public void Renders_text_on_bar()
+        {
+            var cut = Render<Progress>(p => p.Add(x => x.Text, "50%"));
+            Assert.Equal("50%", cut.Find("div.progress-bar span").TextContent);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/QuickTableTests.cs
+++ b/TabBlazor.Tests/Components/QuickTableTests.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using TabBlazor.Components.QuickTables;
+
+namespace TabBlazor.Tests.Components
+{
+    public class QuickTableTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_responsive_wrapper_around_quick_table()
+        {
+            var cut = Render<QuickTable<string>>(p => p
+                .Add(t => t.Items, new[] { "a", "b" }.AsQueryable()));
+
+            var wrapper = cut.Find("div.table-responsive");
+            Assert.NotNull(wrapper);
+            Assert.Single(cut.FindAll("table.quick-table"));
+        }
+
+        [Fact]
+        public void Renders_default_theme_attribute()
+        {
+            var cut = Render<QuickTable<string>>(p => p
+                .Add(t => t.Items, new[] { "a" }.AsQueryable()));
+
+            Assert.Equal("default", cut.Find("table.quick-table").GetAttribute("theme"));
+        }
+
+        [Fact]
+        public void Applies_custom_theme_attribute()
+        {
+            var cut = Render<QuickTable<string>>(p => p
+                .Add(t => t.Theme, "dark")
+                .Add(t => t.Items, new[] { "a" }.AsQueryable()));
+
+            Assert.Equal("dark", cut.Find("table.quick-table").GetAttribute("theme"));
+        }
+
+        [Fact]
+        public void Applies_custom_class_to_wrapper()
+        {
+            var cut = Render<QuickTable<string>>(p => p
+                .Add(t => t.Class, "my-grid")
+                .Add(t => t.Items, new[] { "a" }.AsQueryable()));
+
+            Assert.Contains("my-grid", cut.Find("div.table-responsive").ClassList);
+        }
+
+        [Fact]
+        public void Renders_header_row()
+        {
+            var cut = Render<QuickTable<string>>(p => p
+                .Add(t => t.Items, new[] { "a" }.AsQueryable()));
+
+            Assert.Single(cut.FindAll("thead tr"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/RowColTests.cs
+++ b/TabBlazor.Tests/Components/RowColTests.cs
@@ -1,0 +1,56 @@
+namespace TabBlazor.Tests.Components
+{
+    public class RowColTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_child_content()
+        {
+            var cut = Render<RowCol>(p => p.AddChildContent("content"));
+
+            var div = cut.Find("div");
+            Assert.Contains("content", div.TextContent);
+        }
+
+        [Fact]
+        public void Adds_columns_class()
+        {
+            var cut = Render<RowCol>(p => p.Add(c => c.Columns, 6));
+            Assert.Contains("col-6", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Adds_sm_breakpoint_class()
+        {
+            var cut = Render<RowCol>(p => p.Add(c => c.Sm, 4));
+            Assert.Contains("col-sm-4", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Adds_md_breakpoint_class()
+        {
+            var cut = Render<RowCol>(p => p.Add(c => c.Md, 4));
+            Assert.Contains("col-md-4", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Adds_lg_breakpoint_class()
+        {
+            var cut = Render<RowCol>(p => p.Add(c => c.Lg, 4));
+            Assert.Contains("col-lg-4", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Adds_col_auto_class_when_auto()
+        {
+            var cut = Render<RowCol>(p => p.Add(c => c.Auto, true));
+            Assert.Contains("col-auto", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Omits_column_class_when_unset()
+        {
+            var cut = Render<RowCol>(p => p.AddChildContent("x"));
+            Assert.DoesNotContain("col-0", cut.Find("div").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/RowTests.cs
+++ b/TabBlazor.Tests/Components/RowTests.cs
@@ -1,0 +1,43 @@
+namespace TabBlazor.Tests.Components
+{
+    public class RowTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_div_with_row_class()
+        {
+            var cut = Render<Row>(p => p.AddChildContent("content"));
+
+            var div = cut.Find("div");
+            Assert.Contains("row", div.ClassList);
+            Assert.Contains("content", div.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<Row>(p => p.AddChildContent("<span>Cell</span>"));
+            Assert.Single(cut.FindAll("span"));
+        }
+
+        [Fact]
+        public void Adds_row_cards_class_when_has_cards()
+        {
+            var cut = Render<Row>(p => p.Add(r => r.HasCards, true));
+            Assert.Contains("row-cards", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Omits_row_cards_class_by_default()
+        {
+            var cut = Render<Row>(p => p.AddChildContent("x"));
+            Assert.DoesNotContain("row-cards", cut.Find("div").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<Row>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("div").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/StatusDotTests.cs
+++ b/TabBlazor.Tests/Components/StatusDotTests.cs
@@ -1,0 +1,40 @@
+namespace TabBlazor.Tests.Components
+{
+    public class StatusDotTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_span_with_status_dot_class()
+        {
+            var cut = Render<StatusDot>(p => p.AddChildContent(""));
+            Assert.Contains("status-dot", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Adds_animated_class_when_animate()
+        {
+            var cut = Render<StatusDot>(p => p.Add(s => s.Animate, true));
+            Assert.Contains("status-dot-animated", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<StatusDot>(p => p.Add(s => s.BackgroundColor, TablerColor.Red));
+            Assert.Contains("status-red", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Does_not_add_color_class_for_default_color()
+        {
+            var cut = Render<StatusDot>(p => p.AddChildContent(""));
+            Assert.DoesNotContain("status-default", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Adds_cursor_pointer_when_click_handler_present()
+        {
+            var cut = Render<StatusDot>(p => p.Add(s => s.OnClick, _ => { }));
+            Assert.Contains("cursor-pointer", cut.Find("span").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/StatusIndicatorTests.cs
+++ b/TabBlazor.Tests/Components/StatusIndicatorTests.cs
@@ -1,0 +1,40 @@
+namespace TabBlazor.Tests.Components
+{
+    public class StatusIndicatorTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_span_with_status_indicator_class()
+        {
+            var cut = Render<StatusIndicator>(p => p.AddChildContent(""));
+            Assert.Contains("status-indicator", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Renders_three_indicator_circles()
+        {
+            var cut = Render<StatusIndicator>(p => p.AddChildContent(""));
+            Assert.Equal(3, cut.FindAll("span.status-indicator-circle").Count);
+        }
+
+        [Fact]
+        public void Adds_animated_class_when_animate()
+        {
+            var cut = Render<StatusIndicator>(p => p.Add(s => s.Animate, true));
+            Assert.Contains("status-indicator-animated", cut.Find("span.status-indicator").ClassList);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<StatusIndicator>(p => p.Add(s => s.BackgroundColor, TablerColor.Blue));
+            Assert.Contains("status-blue", cut.Find("span.status-indicator").ClassList);
+        }
+
+        [Fact]
+        public void Adds_cursor_pointer_when_click_handler_present()
+        {
+            var cut = Render<StatusIndicator>(p => p.Add(s => s.OnClick, _ => { }));
+            Assert.Contains("cursor-pointer", cut.Find("span.status-indicator").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/StatusTests.cs
+++ b/TabBlazor.Tests/Components/StatusTests.cs
@@ -1,0 +1,50 @@
+namespace TabBlazor.Tests.Components
+{
+    public class StatusTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_span_with_status_class()
+        {
+            var cut = Render<Status>(p => p.AddChildContent("Active"));
+
+            var span = cut.Find("span");
+            Assert.Contains("status", span.ClassList);
+            Assert.Contains("Active", span.TextContent);
+        }
+
+        [Fact]
+        public void Adds_background_color_class()
+        {
+            var cut = Render<Status>(p => p.Add(s => s.BackgroundColor, TablerColor.Green));
+            Assert.Contains("status-green", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Adds_lite_class_when_lite()
+        {
+            var cut = Render<Status>(p => p.Add(s => s.Lite, true));
+            Assert.Contains("status-lite", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Adds_cursor_pointer_when_click_handler_present()
+        {
+            var cut = Render<Status>(p => p.Add(s => s.OnClick, _ => { }));
+            Assert.Contains("cursor-pointer", cut.Find("span").ClassList);
+        }
+
+        [Fact]
+        public void Renders_status_dot_when_dot_type_set()
+        {
+            var cut = Render<Status>(p => p.Add(s => s.DotType, StatusDotType.Normal));
+            Assert.Contains("status-dot", cut.Find("span span").ClassList);
+        }
+
+        [Fact]
+        public void Renders_animated_dot_when_dot_type_animate()
+        {
+            var cut = Render<Status>(p => p.Add(s => s.DotType, StatusDotType.Animate));
+            Assert.Contains("status-dot-animated", cut.Find("span span").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/TabsTests.cs
+++ b/TabBlazor.Tests/Components/TabsTests.cs
@@ -1,0 +1,39 @@
+namespace TabBlazor.Tests.Components
+{
+    public class TabsTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_card_with_header_tabs()
+        {
+            var cut = Render<Tabs>();
+
+            Assert.Contains("card", cut.Find("div").ClassList);
+            Assert.Single(cut.FindAll("ul.nav-tabs.card-header-tabs"));
+        }
+
+        [Fact]
+        public void Renders_tab_content_container()
+        {
+            var cut = Render<Tabs>();
+
+            Assert.Single(cut.FindAll("div.tab-content"));
+            Assert.Single(cut.FindAll("div.tab-pane.active.show"));
+        }
+
+        [Fact]
+        public void Renders_child_content_into_tab_header()
+        {
+            var cut = Render<Tabs>(p => p.AddChildContent("<li class=\"injected\"></li>"));
+
+            Assert.Single(cut.FindAll("ul.card-header-tabs li.injected"));
+        }
+
+        [Fact]
+        public void Has_no_active_tab_by_default()
+        {
+            var cut = Render<Tabs>();
+
+            Assert.Null(cut.Instance.ActiveTab);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/TimelineItemTests.cs
+++ b/TabBlazor.Tests/Components/TimelineItemTests.cs
@@ -1,0 +1,50 @@
+namespace TabBlazor.Tests.Components
+{
+    public class TimelineItemTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_li_with_timeline_event_class()
+        {
+            var cut = Render<TimelineItem>(p => p.AddChildContent("body"));
+
+            var item = cut.Find("li");
+            Assert.Contains("timeline-event", item.ClassList);
+            Assert.Contains("body", item.TextContent);
+        }
+
+        [Fact]
+        public void Renders_title_in_heading()
+        {
+            var cut = Render<TimelineItem>(p => p.Add(i => i.Title, "Deployed"));
+            Assert.Equal("Deployed", cut.Find("h4").TextContent);
+        }
+
+        [Fact]
+        public void Omits_heading_when_title_empty()
+        {
+            var cut = Render<TimelineItem>(p => p.AddChildContent("body"));
+            Assert.Empty(cut.FindAll("h4"));
+        }
+
+        [Fact]
+        public void Renders_time_label()
+        {
+            var cut = Render<TimelineItem>(p => p.Add(i => i.Time, "10:00"));
+            Assert.Contains("10:00", cut.Find("div.float-end").TextContent);
+        }
+
+        [Fact]
+        public void Renders_icon_text()
+        {
+            var cut = Render<TimelineItem>(p => p.Add(i => i.IconText, "A"));
+            Assert.Contains("A", cut.Find("div.timeline-event-icon").TextContent);
+        }
+
+        [Fact]
+        public void Adds_icon_color_class_to_icon()
+        {
+            var cut = Render<TimelineItem>(p => p.Add(i => i.IconColor, TablerColor.Green));
+            Assert.Contains("bg-green-lt", cut.Find("div.timeline-event-icon").ClassList);
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/TimelineTests.cs
+++ b/TabBlazor.Tests/Components/TimelineTests.cs
@@ -1,0 +1,43 @@
+namespace TabBlazor.Tests.Components
+{
+    public class TimelineTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_ul_with_timeline_class()
+        {
+            var cut = Render<Timeline>(p => p.AddChildContent("events"));
+
+            var list = cut.Find("ul");
+            Assert.Contains("timeline", list.ClassList);
+            Assert.Contains("events", list.TextContent);
+        }
+
+        [Fact]
+        public void Renders_child_content()
+        {
+            var cut = Render<Timeline>(p => p.AddChildContent("<li>Event</li>"));
+            Assert.Single(cut.FindAll("li"));
+        }
+
+        [Fact]
+        public void Adds_timeline_simple_class_when_type_is_simple()
+        {
+            var cut = Render<Timeline>(p => p.Add(t => t.Type, TimelineType.Simple));
+            Assert.Contains("timeline-simple", cut.Find("ul").ClassList);
+        }
+
+        [Fact]
+        public void Omits_timeline_simple_class_by_default()
+        {
+            var cut = Render<Timeline>(p => p.AddChildContent("x"));
+            Assert.DoesNotContain("timeline-simple", cut.Find("ul").ClassList);
+        }
+
+        [Fact]
+        public void Forwards_unmatched_attributes()
+        {
+            var cut = Render<Timeline>(p => p.AddUnmatched("data-test", "value"));
+            Assert.Equal("value", cut.Find("ul").GetAttribute("data-test"));
+        }
+    }
+}

--- a/TabBlazor.Tests/Components/VirtualizeOptionalTests.cs
+++ b/TabBlazor.Tests/Components/VirtualizeOptionalTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class VirtualizeOptionalTests : TabBlazorTestContext
+    {
+        [Fact]
+        public void Renders_each_item_when_not_virtualized()
+        {
+            var cut = Render<VirtualizeOptional<string>>(p => p
+                .Add(v => v.Items, new List<string> { "one", "two" })
+                .Add(v => v.ChildContent, (RenderFragment<string>)(item => builder =>
+                {
+                    builder.OpenElement(0, "span");
+                    builder.AddContent(1, item);
+                    builder.CloseElement();
+                })));
+
+            Assert.Equal(2, cut.FindAll("span").Count);
+            Assert.Contains("one", cut.Markup);
+            Assert.Contains("two", cut.Markup);
+        }
+
+        [Fact]
+        public void Renders_nothing_for_empty_items()
+        {
+            var cut = Render<VirtualizeOptional<string>>(p => p
+                .Add(v => v.Items, new List<string>())
+                .Add(v => v.ChildContent, (RenderFragment<string>)(item => builder =>
+                {
+                    builder.OpenElement(0, "span");
+                    builder.AddContent(1, item);
+                    builder.CloseElement();
+                })));
+
+            Assert.Empty(cut.FindAll("span"));
+        }
+
+        [Fact]
+        public void Renders_template_markup_for_item()
+        {
+            var cut = Render<VirtualizeOptional<int>>(p => p
+                .Add(v => v.Items, new List<int> { 42 })
+                .Add(v => v.ChildContent, (RenderFragment<int>)(item => builder =>
+                {
+                    builder.OpenElement(0, "div");
+                    builder.AddAttribute(1, "class", "row-item");
+                    builder.AddContent(2, item);
+                    builder.CloseElement();
+                })));
+
+            var item = cut.Find("div.row-item");
+            Assert.Equal("42", item.TextContent);
+        }
+    }
+}

--- a/TabBlazor.Tests/EnumHelperTests.cs
+++ b/TabBlazor.Tests/EnumHelperTests.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+
+namespace TabBlazor.Tests
+{
+    public class EnumHelperTests
+    {
+        private enum Sample { First, Second, Third }
+
+        [Fact]
+        public void GetList_returns_all_enum_values()
+        {
+            var result = EnumHelper.GetList<Sample>();
+            Assert.Equal(new[] { Sample.First, Sample.Second, Sample.Third }, result);
+        }
+
+        [Fact]
+        public void GetNullableList_returns_all_values_as_nullable()
+        {
+            var result = EnumHelper.GetNullableList<Sample>();
+            Assert.Equal(3, result.Count);
+            Assert.Contains((Sample?)Sample.Second, result);
+        }
+    }
+}

--- a/TabBlazor.Tests/GlobalUsings.cs
+++ b/TabBlazor.Tests/GlobalUsings.cs
@@ -1,3 +1,4 @@
 // Global using directives
 
+global using Bunit;
 global using Xunit;

--- a/TabBlazor.Tests/PredicateBuilderTests.cs
+++ b/TabBlazor.Tests/PredicateBuilderTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq.Expressions;
+using TabBlazor.Dashboards;
+
+namespace TabBlazor.Tests
+{
+    public class PredicateBuilderTests
+    {
+        [Fact]
+        public void True_matches_everything()
+        {
+            Assert.True(PredicateBuilder.True<int>().Compile()(42));
+        }
+
+        [Fact]
+        public void False_matches_nothing()
+        {
+            Assert.False(PredicateBuilder.False<int>().Compile()(42));
+        }
+
+        [Fact]
+        public void And_requires_both_predicates()
+        {
+            Expression<Func<int, bool>> positive = x => x > 0;
+            Expression<Func<int, bool>> even = x => x % 2 == 0;
+            var predicate = positive.And(even).Compile();
+
+            Assert.True(predicate(4));
+            Assert.False(predicate(3));
+            Assert.False(predicate(-2));
+        }
+
+        [Fact]
+        public void Or_requires_either_predicate()
+        {
+            Expression<Func<int, bool>> negative = x => x < 0;
+            Expression<Func<int, bool>> even = x => x % 2 == 0;
+            var predicate = negative.Or(even).Compile();
+
+            Assert.True(predicate(-3));
+            Assert.True(predicate(4));
+            Assert.False(predicate(3));
+        }
+
+        [Fact]
+        public void Not_inverts_predicate()
+        {
+            Expression<Func<int, bool>> positive = x => x > 0;
+            var predicate = positive.Not().Compile();
+
+            Assert.False(predicate(1));
+            Assert.True(predicate(-1));
+        }
+    }
+}

--- a/TabBlazor.Tests/TabBlazor.Tests.csproj
+++ b/TabBlazor.Tests/TabBlazor.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="bunit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>

--- a/TabBlazor.Tests/TabBlazorTestContext.cs
+++ b/TabBlazor.Tests/TabBlazorTestContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TabBlazor.Tests
+{
+    public abstract class TabBlazorTestContext : BunitContext
+    {
+        protected TabBlazorTestContext()
+        {
+            Services.AddTabBlazor();
+            JSInterop.Mode = JSRuntimeMode.Loose;
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds bUnit-based component testing alongside the existing xUnit setup and broad render coverage for non-interop components.

Closes #229.

## Changes

- **Infra**: `bunit` 2.7.2 (central package management), `TabBlazorTestContext` base that registers `AddTabBlazor()` and sets loose JS interop, `global using Bunit`.
- **Logic tests**: `ClassBuilder`, `EnumHelper`, `PredicateBuilder`.
- **Render tests**: ~38 non-JS-interop components (Button, Badge, Alert, Card family, Avatar, Status, Icon, Dimmer, Progress, Row/RowCol, Page family, Navbar, Timeline, Tabs, DataGrid, QuickTable, Paginator, VirtualizeOptional, NavigationItem, Popover, Input, DetailsRow, …).
- **CI**: `dotnet test` now collects code coverage (`coverlet`) and uploads a cobertura artifact (informational, non-gating).
- **Docs**: `CLAUDE.md` gains a Testing section + the expectation to add tests when editing a component; stale CI/CD notes corrected.

## Test results

213 tests pass locally.

## Not covered (see #229)

JS-interop components, components needing an impractical cascading/generic parent, and `Flag` (assembly-scan `ReflectionTypeLoadException` in the test host).
