### PR TITLE
Close basic dropdown when item selected

### DIFF
--- a/TabBlazor.Tests/Components/DropdownTests.cs
+++ b/TabBlazor.Tests/Components/DropdownTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class DropdownTests : TabBlazorTestContext
+    {
+        private static RenderFragment Menu(bool closeOnClick = true) => builder =>
+        {
+            builder.OpenComponent<DropdownMenu>(0);
+            builder.AddAttribute(1, nameof(DropdownMenu.ChildContent), (RenderFragment)(b =>
+            {
+                b.OpenComponent<DropdownItem>(0);
+                b.AddAttribute(1, nameof(DropdownItem.ChildContent),
+                    (RenderFragment)(c => c.AddContent(0, "Item")));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        };
+
+        private IRenderedComponent<Dropdown> RenderDropdown(bool closeOnClick = true)
+        {
+            return Render<Dropdown>(p => p
+                .Add(d => d.CloseOnClick, closeOnClick)
+                .AddChildContent("Trigger")
+                .Add(d => d.DropdownTemplate, Menu()));
+        }
+
+        [Fact]
+        public void Renders_dropdown_class()
+        {
+            var cut = RenderDropdown();
+            Assert.Contains("dropdown", cut.Find("div.dropdown").ClassList);
+        }
+
+        [Fact]
+        public void Menu_hidden_until_trigger_clicked()
+        {
+            var cut = RenderDropdown();
+            Assert.Empty(cut.FindAll("a.dropdown-item"));
+        }
+
+        [Fact]
+        public void Trigger_click_opens_menu()
+        {
+            var cut = RenderDropdown();
+
+            cut.Find("div.dropdown").Click();
+
+            Assert.True(cut.Instance.IsExpanded);
+            Assert.Single(cut.FindAll("a.dropdown-item"));
+        }
+
+        [Fact]
+        public void Item_click_closes_menu_when_close_on_click()
+        {
+            var cut = RenderDropdown(closeOnClick: true);
+            cut.Find("div.dropdown").Click();
+
+            cut.Find("a.dropdown-item").Click();
+
+            Assert.False(cut.Instance.IsExpanded);
+            Assert.Empty(cut.FindAll("a.dropdown-item"));
+        }
+
+        [Fact]
+        public void Item_click_keeps_menu_open_when_not_close_on_click()
+        {
+            var cut = Render<Dropdown>(p => p
+                .Add(d => d.CloseOnClick, false)
+                .AddChildContent("Trigger")
+                .Add(d => d.DropdownTemplate, Menu()));
+            cut.Find("div.dropdown").Click();
+
+            cut.Find("a.dropdown-item").Click();
+
+            Assert.True(cut.Instance.IsExpanded);
+            Assert.Single(cut.FindAll("a.dropdown-item"));
+        }
+    }
+}

--- a/src/TabBlazor/Components/Dropdowns/Dropdown.razor
+++ b/src/TabBlazor/Components/Dropdowns/Dropdown.razor
@@ -14,7 +14,7 @@
 
         @if (isExpanded)
         {
-            <div @ref="popperEl" class="@(UsePopper ? "popper-host" : null)" @onclick:stopPropagation="!CloseOnClick">
+            <div @ref="popperEl" class="@(UsePopper ? "popper-host" : null)" @onclick:stopPropagation="true">
                 @DropdownTemplate
             </div>
 

--- a/src/TabBlazor/Components/Dropdowns/DropdownItem.razor.cs
+++ b/src/TabBlazor/Components/Dropdowns/DropdownItem.razor.cs
@@ -22,7 +22,6 @@ namespace TabBlazor
 
         /// <summary>Optional nested sub-menu content shown on hover/click.</summary>
         [Parameter] public RenderFragment SubMenu { get; set; }
-        private List<DropdownItem> subItems = new();
 
         private bool hasSubMenu => SubMenu != null;
         private bool subMenuVisible;


### PR DESCRIPTION
## Summary
Fixes the basic dropdown not closing/selecting on item click (#106).

Menu clicks now always stop propagation to the dropdown root. Previously, with the default `CloseOnClick=true`, an item click called `Dropdown.Close()` but the event bubbled to the root toggle handler (`OnDropdownClick` → `Toogle()`) and reopened the menu — so the item appeared neither closed nor selected. The `@onclick:stopPropagation` condition was inverted (`!CloseOnClick`); closing is handled explicitly by `DropdownItem`, so the root toggle should never fire from a menu click.

## Changes
- `Dropdown.razor`: menu wrapper `@onclick:stopPropagation="true"` (was `!CloseOnClick`)
- `DropdownTests.cs`: new tests — open on trigger, close on item click (`CloseOnClick=true`), keep open (`CloseOnClick=false`)

The default (non-Popper) positioning path needs no JS interop, so it is fully bUnit-testable — this was the coverage gap that let #106 slip through.

Closes #106