### PR TITLE
Apply sorting in external data source table demo

### DIFF
--- a/docs/Tabler.Docs/Components/Tables/TablesExternalDataSourceWithSortingAndPaging.razor
+++ b/docs/Tabler.Docs/Components/Tables/TablesExternalDataSourceWithSortingAndPaging.razor
@@ -66,9 +66,20 @@
 
         public async Task<IEnumerable<TableResult<object, Item>>> GetData(List<IColumn<Item>> columns, ITableState<Item> state, IEnumerable<Item> items, bool resetPage = false, bool addSorting = true, Item moveToItem = null)
         {
-            //here you have to implement your own service call  for data and implement correctly sorting, paging ,grouping to get full benefit of this interface and Table implementation.
-            var list = viewResult.First().Skip(state.PageNumber * state.PageSize).Take(state.PageSize).ToList();
-            state.TotalCount = viewResult.SelectMany(vr => vr).Count();
+            //Replace this with your own service call. The columns argument carries the active sort column,
+            //so apply sorting (and grouping if needed) before paging to get the full benefit of this interface.
+            var query = viewResult.SelectMany(vr => vr).AsQueryable();
+
+            var sortColumn = columns?.FirstOrDefault(c => c.SortColumn);
+            if (addSorting && sortColumn != null)
+            {
+                query = sortColumn.SortDescending
+                    ? query.OrderByDescending(sortColumn.PropertyNullSafe)
+                    : query.OrderBy(sortColumn.PropertyNullSafe);
+            }
+
+            state.TotalCount = query.Count();
+            var list = query.Skip(state.PageNumber * state.PageSize).Take(state.PageSize).ToList();
             return await Task.FromResult(new List<TableResult<object, Item>> {new(null, list)});
         }
     }


### PR DESCRIPTION
## What

Fixes #190 — sorting did nothing on the External DataSource table demo.

## Root cause

The table machinery is fine: clicking a sortable header calls `Column.SortByAsync()`, which sets `SortColumn`/`SortDescending` and calls `Table.Update()`, which re-invokes `DataProvider.GetData(Columns, …)`. The columns carry the active sort state.

The **demo's** `MyCustomDataSource.GetData` ignored the `columns` argument entirely and only did `Skip/Take` for paging, so the sort flags were never applied.

## Change

In the demo provider, apply the active sort column (honoring `SortDescending` and the `addSorting` flag) before paging, mirroring the built-in `TheGridDataFactory.AddSorting`. This makes the demo a correct reference implementation of the `IDataProvider` contract.

Demo-only; no library code changed.

## Verification

Built `Tabler.Docs` (0 errors). Run the WASM demo → External DataSource table → click the *Customer* header: rows sort ascending/descending and paging still works.
