### PR TITLE
Reload table data only when its parameters change

### DIFF
--- a/TabBlazor.Tests/Components/TableReloadTests.cs
+++ b/TabBlazor.Tests/Components/TableReloadTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using TabBlazor.Components.Tables;
+using TabBlazor.Components.Tables.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class TableReloadTests : TabBlazorTestContext
+    {
+        private sealed class CountingProvider : IDataProvider<string>
+        {
+            public int Calls { get; private set; }
+
+            public Task<IEnumerable<TableResult<object, string>>> GetData(
+                List<IColumn<string>> columns, ITableState<string> state, IEnumerable<string> items,
+                bool resetPage = false, bool addSorting = true, string moveToItem = default)
+            {
+                Calls++;
+                var rows = (items ?? Enumerable.Empty<string>()).ToList();
+                return Task.FromResult<IEnumerable<TableResult<object, string>>>(
+                    new[] { new TableResult<object, string>(null, rows) });
+            }
+        }
+
+        private IRenderedComponent<Table<string>> RenderTable(CountingProvider provider, IList<string> items) =>
+            Render<Table<string>>(p => p
+                .Add(t => t.DataProvider, provider)
+                .Add(t => t.Items, items)
+                .AddChildContent<Column<string>>(c => c.Add(x => x.Title, "Value")));
+
+        // Re-applies the given parameters to the table, re-invoking OnParametersSetAsync,
+        // as a parent re-render does. Omitted parameters keep their current values.
+        private static void ReapplyParameters(IRenderedComponent<Table<string>> cut, IDataProvider<string> provider, IList<string> items) =>
+            cut.Render(ParameterView.FromDictionary(new Dictionary<string, object>
+            {
+                [nameof(Table<string>.DataProvider)] = provider,
+                [nameof(Table<string>.Items)] = items,
+            }));
+
+        [Fact]
+        public void Does_not_refetch_when_parameters_resupplied_unchanged()
+        {
+            var provider = new CountingProvider();
+            var items = new List<string> { "a", "b", "c" };
+            var cut = RenderTable(provider, items);
+            var afterInit = provider.Calls;
+
+            ReapplyParameters(cut, provider, items);
+
+            Assert.Equal(afterInit, provider.Calls);
+        }
+
+        [Fact]
+        public void Refetches_when_items_instance_changes()
+        {
+            var provider = new CountingProvider();
+            var cut = RenderTable(provider, new List<string> { "a" });
+            var afterInit = provider.Calls;
+
+            ReapplyParameters(cut, provider, new List<string> { "a", "b" });
+
+            Assert.True(provider.Calls > afterInit, $"afterInit={afterInit} now={provider.Calls}");
+        }
+
+        [Fact]
+        public void Refetches_when_items_count_changes_on_same_instance()
+        {
+            var provider = new CountingProvider();
+            var items = new List<string> { "a" };
+            var cut = RenderTable(provider, items);
+            var afterInit = provider.Calls;
+
+            items.Add("b");
+            ReapplyParameters(cut, provider, items);
+
+            Assert.True(provider.Calls > afterInit, $"afterInit={afterInit} now={provider.Calls}");
+        }
+    }
+}

--- a/src/TabBlazor/Components/Tables/Components/Table.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Table.razor.cs
@@ -95,6 +95,8 @@ namespace TabBlazor
         /// <summary>When true, the editing row is dimmed while its save handler runs. Defaults to true.</summary>
         [Parameter] public bool ShowSavingDimmer { get; set; } = true;
 
+        private RefreshState lastRefreshState;
+
         public async Task OnValidSubmit(EditContext editContext)
         {
             IsSaving = true;
@@ -401,7 +403,31 @@ namespace TabBlazor
 
         protected override async Task OnParametersSetAsync()
         {
-            await Update();
+            var current = RefreshState.Capture(this);
+            var needsRefresh = current.NeedsRefresh(lastRefreshState);
+            lastRefreshState = current;
+
+            if (needsRefresh)
+            {
+                await Update();
+            }
+        }
+
+        private sealed record RefreshState(
+            IList<Item> Items,
+            int? ItemsCount,
+            IDataProvider<Item> DataProvider,
+            int PageSize)
+        {
+            public static RefreshState Capture(ITable<Item> table) =>
+                new(table.Items, table.Items?.Count, table.DataProvider, table.PageSize);
+
+            public bool NeedsRefresh(RefreshState previous) =>
+                previous is null
+                || !ReferenceEquals(Items, previous.Items)
+                || ItemsCount != previous.ItemsCount
+                || !ReferenceEquals(DataProvider, previous.DataProvider)
+                || PageSize != previous.PageSize;
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
Closes #197

## Problem
`Table.OnParametersSetAsync` called `Update()` (→ `DataProvider.GetData`) unconditionally. Blazor invokes `OnParametersSet` on **every parent re-render**, so changing any unrelated input elsewhere on the page re-ran the data provider and hit the database — even when nothing the table queries on had changed.

## Change
Snapshot the query-relevant parameters into a small `RefreshState` and only reload when it differs from the previous render:

```csharp
protected override async Task OnParametersSetAsync()
{
    var current = RefreshState.Capture(this);
    var needsRefresh = current.NeedsRefresh(lastRefreshState);
    lastRefreshState = current;
    if (needsRefresh) await Update();
}
```

`RefreshState` (captured from `ITable`) compares `Items` reference, `Items` count, `DataProvider` reference, and `PageSize`. Intentional reloads (search, sort, paging, save, delete) call `Update()` directly and are unaffected.

### For external filter fields
Server-side consumers who previously relied on the per-render refetch now refresh on demand via the existing public `Update()`:

```razor
<input type="date" @bind="fromDate" @bind:after="ReloadAsync" />
<Table @ref="table" DataProvider="claimDataProvider" ... />
@code { Task ReloadAsync() => table.Update(resetPage: true); }
```

## Tests
Three bUnit tests (`TableReloadTests`): no refetch when parameters are re-supplied unchanged; refetch when the `Items` instance changes; refetch when the item count changes on the same instance.

## Verification
- Full solution build: 0 errors.
- Full test suite: 221 passed (incl. 3 new).

## Note
Behavior change: a table whose `Items` list is mutated **in place with the same count** (rare) no longer auto-reloads on an unrelated re-render — call `Update()` to refresh. This is the intended trade to stop the spurious database calls.