### PR TITLE
Add custom edit modal mode to Table

### DIFF
--- a/TabBlazor.Tests/Components/TableCustomEditTests.cs
+++ b/TabBlazor.Tests/Components/TableCustomEditTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using TabBlazor.Components.Tables;
+using TabBlazor.Components.Tables.Components;
+
+namespace TabBlazor.Tests.Components
+{
+    public class TableCustomEditTests : TabBlazorTestContext
+    {
+        private sealed class Row
+        {
+            public string? Name { get; set; }
+        }
+
+        private IRenderedComponent<Table<Row>> RenderTable(
+            IList<Row> rows,
+            Func<Row, Task<ModalResult>> customEdit,
+            EventCallback<Row> onEdited = default,
+            EventCallback<Row> onAdded = default)
+        {
+            return Render<Table<Row>>(p =>
+            {
+                p.Add(t => t.EditMode, TableEditMode.Custom);
+                p.Add(t => t.CustomEdit, customEdit);
+                p.Add(t => t.Items, rows);
+                if (onEdited.HasDelegate) p.Add(t => t.OnItemEdited, onEdited);
+                if (onAdded.HasDelegate) p.Add(t => t.OnItemAdded, onAdded);
+                p.AddChildContent<Column<Row>>(c => c.Add(x => x.Title, "Name"));
+            });
+        }
+
+        private EventCallback<Row> Callback(Action<Row> handler) =>
+            EventCallback.Factory.Create(this, handler);
+
+        [Fact]
+        public async Task Edit_invokes_CustomEdit_and_raises_OnItemEdited_on_ok()
+        {
+            var row = new Row { Name = "before" };
+            Row? editArg = null;
+            Row? editedResult = null;
+
+            Task<ModalResult> CustomEdit(Row r)
+            {
+                editArg = r;
+                r.Name = "after";
+                return Task.FromResult(ModalResult.Ok(r));
+            }
+
+            var cut = RenderTable(new List<Row> { row }, CustomEdit, onEdited: Callback(r => editedResult = r));
+
+            await cut.InvokeAsync(() => cut.Instance.EditItemAsync(row));
+
+            Assert.Same(row, editArg);
+            Assert.Same(row, editedResult);
+            Assert.Equal("after", row.Name);
+        }
+
+        [Fact]
+        public async Task Edit_does_not_raise_OnItemEdited_on_cancel()
+        {
+            var row = new Row { Name = "x" };
+            var raised = false;
+
+            Task<ModalResult> CustomEdit(Row r) => Task.FromResult(ModalResult.Cancel());
+
+            var cut = RenderTable(new List<Row> { row }, CustomEdit, onEdited: Callback(_ => raised = true));
+
+            await cut.InvokeAsync(() => cut.Instance.EditItemAsync(row));
+
+            Assert.False(raised);
+        }
+
+        [Fact]
+        public void Add_button_invokes_CustomEdit_and_raises_OnItemAdded_on_ok()
+        {
+            var rows = new List<Row>();
+            Row? added = null;
+
+            Task<ModalResult> CustomEdit(Row r) => Task.FromResult(ModalResult.Ok(r));
+
+            var cut = RenderTable(rows, CustomEdit, onAdded: Callback(r => { added = r; rows.Add(r); }));
+
+            cut.Find("button.add-row").Click();
+
+            Assert.NotNull(added);
+            Assert.Contains(added, rows);
+        }
+    }
+}

--- a/docs/Tabler.Docs/Components/Tables/CustomOrderEditModal.razor
+++ b/docs/Tabler.Docs/Components/Tables/CustomOrderEditModal.razor
@@ -1,0 +1,36 @@
+@inject IModalService ModalService
+
+<div>
+    <Row>
+        <RowCol Md="6">
+            <label class="form-label">Customer</label>
+            <input class="form-control" @bind-value="Model.Customer.CustomerName" />
+        </RowCol>
+        <RowCol Md="6">
+            <label class="form-label">Country</label>
+            <input class="form-control" @bind-value="Model.Country" />
+        </RowCol>
+    </Row>
+    <Row class="mt-3">
+        <RowCol Md="6">
+            <label class="form-label">Order type</label>
+            <Select Items="EnumHelper.GetList<OrderType>()" @bind-SelectedValue="Model.OrderType" TextExpression="e => e.ToString()" ValueExpression="e => e" />
+        </RowCol>
+        <RowCol Md="6">
+            <label class="form-label">Discount %</label>
+            <input type="number" class="form-control" @bind-value="Model.DiscountPercentage" />
+        </RowCol>
+    </Row>
+
+    <div class="d-flex mt-4">
+        <Button BackgroundColor="TablerColor.Secondary" OnClick="Cancel">Cancel</Button>
+        <Button BackgroundColor="TablerColor.Primary" class="ms-auto" OnClick="Save">Save</Button>
+    </div>
+</div>
+
+@code {
+    [Parameter] public Order Model { get; set; }
+
+    private void Save() => ModalService.Close(ModalResult.Ok(Model));
+    private void Cancel() => ModalService.Close(ModalResult.Cancel());
+}

--- a/docs/Tabler.Docs/Components/Tables/Tables.razor
+++ b/docs/Tabler.Docs/Components/Tables/Tables.razor
@@ -21,7 +21,16 @@
         <CodeSnippet SetBackground Component="@typeof(TableCustomRowAction)" Title="Custom Row Actions"/>
 
         <CodeSnippet SetBackground Component="@typeof(TablesEdit)" Title="Edit"/>
-        
+
+        <CodeSnippet SetBackground Component="@typeof(TablesCustomEdit)" Title="Custom edit modal">
+            <Description>
+                Set <code>EditMode="TableEditMode.Custom"</code> and supply a <code>CustomEdit</code> delegate that
+                shows your own component as a modal and returns a <code>ModalResult</code>. Your component owns the
+                layout and validation; on a non-cancelled result the table raises <code>OnItemEdited</code> /
+                <code>OnItemAdded</code> and refreshes.
+            </Description>
+        </CodeSnippet>
+
         <CodeSnippet SetBackground Component="@typeof(TablesEditWithCancelStrategy)" Title="Edit with cancel strategy">
             <Description>
                 When editing a row and the cancelled button is clicked, the state of the line will be reverted to how it initially was.<br/>

--- a/docs/Tabler.Docs/Components/Tables/TablesCustomEdit.razor
+++ b/docs/Tabler.Docs/Components/Tables/TablesCustomEdit.razor
@@ -1,0 +1,40 @@
+@inject IModalService ModalService
+
+<Table Item="Order" Items="orders" PageSize="10"
+       EditMode="TableEditMode.Custom"
+       CustomEdit="EditOrderAsync"
+       OnItemEdited="OnOrderSaved"
+       OnItemAdded="OnOrderAdded"
+       OnItemDeleted="OnOrderDeleted"
+       AddItemFactory="CreateOrder"
+       Hover Responsive>
+    <HeaderTemplate>
+        <strong>Orders</strong>
+    </HeaderTemplate>
+    <ChildContent>
+        <Column Item="Order" Property="e=>e.Customer.CustomerName" Title="Customer" Sortable Searchable />
+        <Column Item="Order" Property="e=>e.Country" Title="Country" Sortable Searchable />
+        <Column Item="Order" Property="e=>e.OrderType" Title="Order type" Sortable />
+        <Column Item="Order" Property="e=>e.DiscountPercentage" Title="Discount %" />
+    </ChildContent>
+</Table>
+
+@code {
+    private List<Order> orders = SampleData.GetOrders();
+
+    // EditMode=Custom: show your own modal for the item and return its ModalResult.
+    private Task<ModalResult> EditOrderAsync(Order order) =>
+        ModalService.ShowAsync<CustomOrderEditModal>("Edit order",
+            new RenderComponent<CustomOrderEditModal>().Set(c => c.Model, order));
+
+    // The edited item is mutated in place, so this only needs to persist/refresh.
+    private void OnOrderSaved(Order order) { }
+
+    // In Custom mode the table does not insert new items into the list, so add it here.
+    private void OnOrderAdded(Order order) => orders.Add(order);
+
+    private void OnOrderDeleted(Order order) { }
+
+    private Task<Order> CreateOrder() =>
+        Task.FromResult(new Order { Customer = new Customer("New customer") });
+}

--- a/docs/Tabler.Docs/Components/Tables/TablesEdit.razor
+++ b/docs/Tabler.Docs/Components/Tables/TablesEdit.razor
@@ -1,7 +1,7 @@
 ﻿<Row class="mb-3">
     <RowCol Sm="12" Md="6" Lg="4">
         <label class="form-label">Edit Mode</label>
-        <Select Items="EnumHelper.GetList<TableEditMode>()" @bind-SelectedValue="@tableEditMode" TextExpression="e=> e.ToString()" />
+        <Select Items="editModes" @bind-SelectedValue="@tableEditMode" TextExpression="e=> e.ToString()" />
     </RowCol>
 </Row>
 
@@ -47,6 +47,9 @@
     private static List<Order> orders = SampleData.GetOrders();
   
     private TableEditMode tableEditMode;
+
+    // Custom mode has its own demo (TablesCustomEdit); this demo covers the built-in editors.
+    private readonly List<TableEditMode> editModes = new() { TableEditMode.Inline, TableEditMode.Popup };
 
 
     private async Task OnItemEdit(Order order)

--- a/src/TabBlazor/Components/Tables/Components/Table.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Table.razor.cs
@@ -70,13 +70,22 @@ namespace TabBlazor
         /// <summary>How rows are edited (e.g. inline or popup).</summary>
         [Parameter] public TableEditMode EditMode { get; set; }
 
+        /// <summary>
+        /// Required when <see cref="EditMode"/> is <see cref="TableEditMode.Custom"/>. Invoked when a row is
+        /// edited or a new row is added; show your own modal for the supplied item and return its
+        /// <see cref="ModalResult"/>. On a non-cancelled result the table raises <see cref="OnItemEdited"/> /
+        /// <see cref="OnItemAdded"/> (with the result's data, or the original item) and refreshes. The custom
+        /// component owns layout and validation.
+        /// </summary>
+        [Parameter] public Func<Item, Task<ModalResult>> CustomEdit { get; set; }
+
         [Parameter] public OnCancelStrategy? CancelStrategy { get; set; }
 
         protected IEnumerable<TableResult<object, Item>> TempItems { get; set; } = Enumerable.Empty<TableResult<object, Item>>();
         public bool ReloadingItems { get; set; }
         protected IDictionary<string, object> Attributes { get; set; }
         public bool ChangedItem { get; set; }
-        public bool AllowAdd => OnItemAdded.HasDelegate;
+        public bool AllowAdd => OnItemAdded.HasDelegate && (EditMode != TableEditMode.Custom || CustomEdit != null);
         public bool HasGrouping => Columns.Any(x => x.GroupBy);
         [Parameter] public RenderFragment<Item> DetailsTemplate { get; set; }
         [Parameter] public Func<Item, bool> ShowDetails { get; set; }
@@ -318,7 +327,9 @@ namespace TabBlazor
         [Parameter] public Func<Item, bool> AllowEditExpression { get; set; }
         [Parameter] public bool KeyboardNavigation { get; set; }
         public bool AllowDelete => OnItemDeleted.HasDelegate;
-        public bool AllowEdit => OnItemEdited.HasDelegate && !IsAddInProgress;
+        public bool AllowEdit =>
+            (EditMode == TableEditMode.Custom ? CustomEdit != null : OnItemEdited.HasDelegate)
+            && !IsAddInProgress;
         public Item SelectedItem { get; set; }
 
         public async Task RowClicked(Item item)
@@ -397,6 +408,26 @@ namespace TabBlazor
 
             CurrentEditItem = tableItem;
             StateHasChanged();
+        }
+
+        public async Task EditItemAsync(Item tableItem)
+        {
+            if (EditMode == TableEditMode.Custom)
+            {
+                if (CustomEdit is null) return;
+
+                var result = await CustomEdit(tableItem);
+                if (result is { Cancelled: false })
+                {
+                    var edited = result.Data is Item updated ? updated : tableItem;
+                    await OnItemEdited.InvokeAsync(edited);
+                    await Update();
+                }
+
+                return;
+            }
+
+            EditItem(tableItem);
         }
 
         [Parameter] public bool UseNaturalSort { get; set; } = false;
@@ -513,6 +544,25 @@ namespace TabBlazor
         {
             if (IsAddInProgress)
             {
+                return;
+            }
+
+            if (EditMode == TableEditMode.Custom)
+            {
+                if (CustomEdit is null) return;
+
+                var newItem = AddItemFactory != null
+                    ? await AddItemFactory()
+                    : (Item)Activator.CreateInstance(typeof(Item));
+
+                var result = await CustomEdit(newItem);
+                if (result is { Cancelled: false })
+                {
+                    var added = result.Data is Item created ? created : newItem;
+                    await OnItemAdded.InvokeAsync(added);
+                    await Update();
+                }
+
                 return;
             }
 

--- a/src/TabBlazor/Components/Tables/Components/TableRow.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/TableRow.razor.cs
@@ -108,9 +108,9 @@ namespace TabBlazor.Components.Tables
             await Table.OnDeleteItem(Item);
         }
 
-        protected void Edit()
+        protected Task Edit()
         {
-            Table.EditItem(Item);
+            return Table.EditItemAsync(Item);
         }
 
     }

--- a/src/TabBlazor/Components/Tables/ITable.cs
+++ b/src/TabBlazor/Components/Tables/ITable.cs
@@ -117,6 +117,7 @@ namespace TabBlazor.Components.Tables
         EventCallback<List<TableItem>> SelectedItemsChanged { get; }
         Task OnDeleteItem(TableItem item);
         void EditItem(TableItem item);
+        Task EditItemAsync(TableItem item);
         Task SetSelectedItem(TableItem item);
         Task RowClicked(TableItem item);
         bool KeyboardNavigation { get; }

--- a/src/TabBlazor/Components/Tables/TableEditMode.cs
+++ b/src/TabBlazor/Components/Tables/TableEditMode.cs
@@ -3,6 +3,7 @@
     public enum TableEditMode
     {
         Inline = 0,
-        Popup = 1
+        Popup = 1,
+        Custom = 2
     }
 }


### PR DESCRIPTION
Closes #125

## Problem
The `Table` only offers `Inline` and `Popup` edit modes, both of which render a canned, column-derived editor. As #125 notes, that can't lay fields out in a richer way (e.g. an address block) or edit model members that aren't shown as columns.

## Change
A third edit mode, `TableEditMode.Custom`, hands editing/adding to a developer-supplied component shown as a modal. The developer owns layout and validation.

- New `[Parameter] Func<Item, Task<ModalResult>> CustomEdit` on `Table`.
- `EditItemAsync` (and the add path) route through `CustomEdit` in Custom mode; the existing inline/popup paths are unchanged.
- On a non-cancelled `ModalResult`, the table raises `OnItemEdited` (edit) / `OnItemAdded` (add) with the result's data (or the original item) and refreshes via `Update()`.
- Add routes a freshly created item through the same delegate and is committed **only on success**, so a cancel leaves the list untouched. (Unlike the canned add, the table does not pre-insert the new item — the consumer adds it in `OnItemAdded`.)
- `ITableRow.EditItemAsync` added; `TableRow`'s edit click now awaits it. `AllowEdit`/`AllowAdd` require `CustomEdit` in Custom mode.

## Usage
```razor
<Table Items="people" EditMode="TableEditMode.Custom" CustomEdit="EditPersonAsync" OnItemEdited="Refresh" ... />

@code {
    [Inject] IModalService ModalService { get; set; }
    Task<ModalResult> EditPersonAsync(Person p) =>
        ModalService.ShowAsync<PersonEditModal>("Edit person",
            new RenderComponent<PersonEditModal>().Set(c => c.Model, p));
    // PersonEditModal does its own layout/validation, then ModalService.Close(ModalResult.Ok(p))
}
```

## Demo
New `TablesCustomEdit` demo + `CustomOrderEditModal` component, registered on the Tables docs page (`/docs/tables`).

## Tests
`TableCustomEditTests` (bUnit): edit invokes `CustomEdit` and raises `OnItemEdited` on Ok; no `OnItemEdited` on Cancel; the Add-row button invokes `CustomEdit` and raises `OnItemAdded` on Ok.

## Verification
- Full solution build: 0 errors.
- Full test suite: 224 passed (incl. 3 new).