### PR TITLE
Migrate docs example pages to Description and ChildContent slots

### DIFF
--- a/docs/Tabler.Docs/Components/Alerts/Alerts.razor
+++ b/docs/Tabler.Docs/Components/Alerts/Alerts.razor
@@ -3,31 +3,39 @@
 <div class="page">
 
     <DocsExample Title="Alerts" ComponentType="typeof(Alert)">
-        <p>Alert messages are used to inform users of the status of their action and help them solve any problems that might have occurred. Good design of alert modals is very important for the overall user experience of a website or app.</p>
+        <Description>Alert messages are used to inform users of the status of their action and help them solve any
+            problems that might have occurred. Good design of alert modals is very important for the overall user
+            experience of a website or app.
+        </Description>
+        <ChildContent>
+            <CodeSnippet Component="@typeof(AlertsBasic)" Title="Basic Setup">
+                <Description>
+                    Depending on the information you need to convey, you can use one of the following types of alert
+                    messages - success, info, warning or danger. Using the right type of alert modal will help draw
+                    users’
+                    attention to the message and prompt them to take action.
+                </Description>
+            </CodeSnippet>
 
-        <CodeSnippet Component="@typeof(AlertsBasic)" Title="Basic Setup">
-            <Description>
-                Depending on the information you need to convey, you can use one of the following types of alert messages - success, info, warning or danger. Using the right type of alert modal will help draw users’ attention to the message and prompt them to take action.
-            </Description>
-        </CodeSnippet>
+            <CodeSnippet Component="@typeof(AlertsDismissable)" Title="Dismissible">
+                <Description>
+                    Set Dismissible to make an alert modal dismissible. Thanks to that, your alert modal will disappear
+                    only
+                    once the user closes it.
+                </Description>
+            </CodeSnippet>
 
-        <CodeSnippet Component="@typeof(AlertsDismissable)" Title="Dismissible">
-            <Description>
-                Set Dismissible to make an alert modal dismissible. Thanks to that, your alert modal will disappear only once the user closes it.
-            </Description>
-        </CodeSnippet>
+            <CodeSnippet Component="@typeof(AlertsTemplate)" Title="Templates">
+                <Description>
+                    <p>Using the template you can control the content of the alert</p>
+                </Description>
+            </CodeSnippet>
 
-        <CodeSnippet Component="@typeof(AlertsTemplate)" Title="Templates">
-            <Description>
-                <p>Using the template you can control the content of the alert</p>
-            </Description>
-        </CodeSnippet>
-
-        <CodeSnippet Component="@typeof(AlertsImportant)" Title="Important">
-            <Description>
-                <p>Set the important property to have the alert really standout</p>
-            </Description>
-        </CodeSnippet>
-
+            <CodeSnippet Component="@typeof(AlertsImportant)" Title="Important">
+                <Description>
+                    <p>Set the important property to have the alert really standout</p>
+                </Description>
+            </CodeSnippet>
+        </ChildContent>
     </DocsExample>
 </div>

--- a/docs/Tabler.Docs/Components/DocsExample.razor
+++ b/docs/Tabler.Docs/Components/DocsExample.razor
@@ -6,14 +6,17 @@
             {
                 <Row>
                     <RowCol Auto>
-                        <a href="https://github.com/joadan/Blazor-Tabler" class="btn btn-white btn-block mb-2" target="_blank" rel="noreferrer">
+                        <a href="https://github.com/joadan/Blazor-Tabler" class="btn btn-white btn-block mb-2"
+                           target="_blank" rel="noreferrer">
                             <Icon IconType="@TablerIcons.Brand_github"/>
                             Browse source code
                         </a>
                     </RowCol>
                     <RowCol Auto>
-                        <Button BackgroundColor=TablerColor.White class="p-2  btn-icon mb-2" OnClick="OpenComponentModal">
-                            <Icon IconType="@TablerIcons.Code" class="me-2"/> Component API
+                        <Button BackgroundColor=TablerColor.White class="p-2  btn-icon mb-2"
+                                OnClick="OpenComponentModal">
+                            <Icon IconType="@TablerIcons.Code" class="me-2"/>
+                            Component API
                         </Button>
                     </RowCol>
                 </Row>
@@ -31,17 +34,17 @@
         </div>
     </RowCol>
     <RowCol class="order-lg-first order-md-last order-sm-last order-last" Lg="9" Md="12" Sm="12">
-        <Card Size="CardSize.Default">
-            <CardBody>
-                <div class="d-flex">
-                    <h3 class="h1 mt-0 mb-3">@Title</h3>
-                </div>
-                @Description
-
-                <CascadingValue Value="@this">
-                    @ChildContent
-                </CascadingValue>
-            </CardBody>
-        </Card>
+        <div class="d-flex">
+            <h3 class="h1 m-0">@Title</h3>
+        </div>
+        @if (Description != null)
+        {
+            <div class="fst-italic fs-5">@Description</div>
+        }
+        <div class="mt-2">
+            <CascadingValue Value="@(this)">
+                @ChildContent
+            </CascadingValue>
+        </div>
     </RowCol>
 </div>

--- a/docs/Tabler.Docs/Components/Helpers/ClickOutside/ClickOutsideSamples.razor
+++ b/docs/Tabler.Docs/Components/Helpers/ClickOutside/ClickOutsideSamples.razor
@@ -2,13 +2,12 @@
 
 <Page>
     <DocsExample Title="Click outside" ComponentType="typeof(ClickOutside)">
-        <p>Sends an event if user clicks outside of the container</p>
-        <p>Each ClickOutside component get an event when the user click outside of it.</p>
-
-        <CodeSnippet Component="@typeof(Basic)" Title="Basic"/>
-
-
-        <CodeSnippet Component="@typeof(Multiple)" Title="Multiple components recieving click outside"/>
-
+        <Description>
+            <p>Sends an event if user clicks outside of the container. Each ClickOutside component get an event when the user click outside of it.</p>
+        </Description>
+        <ChildContent>
+            <CodeSnippet Component="@typeof(Basic)" Title="Basic"/>
+            <CodeSnippet Component="@typeof(Multiple)" Title="Multiple components recieving click outside"/>
+        </ChildContent>
     </DocsExample>
 </Page>

--- a/docs/Tabler.Docs/Components/Helpers/ResizeObserver/ResizeObserverSamples.razor
+++ b/docs/Tabler.Docs/Components/Helpers/ResizeObserver/ResizeObserverSamples.razor
@@ -2,10 +2,10 @@
 
 <Page>
     <DocsExample Title="Resize Observer" ComponentType="typeof(ResizeObserver)">
-        <p>ResizeObserver tracks resize events using the Resize Observer API. Resize the browser to see it in action</p>
-        <CodeSnippet Component="@typeof(Basic)" Title="Basic"/>
-
-
-
+        <Description><p>ResizeObserver tracks resize events using the Resize Observer API. Resize the browser to see it
+                in action</p></Description>
+        <ChildContent>
+            <CodeSnippet Component="@typeof(Basic)" Title="Basic"/>
+        </ChildContent>
     </DocsExample>
 </Page>

--- a/docs/Tabler.Docs/Components/Icons/Icons.razor
+++ b/docs/Tabler.Docs/Components/Icons/Icons.razor
@@ -2,50 +2,54 @@
 
 <Page>
     <DocsExample Title="Icons" ComponentType="typeof(ListIcon)">
+        <Description>
+            <div>
+                <p>
+                    Icons are not included by default. Just create a static class and select/copy the icons from the
+                    list below.<br/>
+                    If you want all icons you can find them <a
+                        href="https://github.com/joadan/TabBlazor/blob/master/docs/Tabler.Docs/Icons/DemoIcons.cs"
+                        target="_blank">here</a>.
+                </p>
+            </div>
 
-        <div class="mb-1">
-            <p>
-                Icons are not included by default. Just create a static class and select/copy the icons from the list below.<br />
-                If you want all icons you can find them <a href="https://github.com/joadan/TabBlazor/blob/master/docs/Tabler.Docs/Icons/DemoIcons.cs" target="_blank">here</a>.
-            </p>
-        </div>
-        
-        <div class="mb-2">
-            All icons come from the Tabler Icons set and are MIT-licensed
-            <a href="https://tabler-icons.io" target="_blank" rel="noopener">tabler-icons.io</a>
-            <Icon class="align-text-top" Size=16 IconType="@TablerIcons.Heart" TextColor="TablerColor.Red" Filled=true />
-        </div>
-
-     
-
-        <CodeSnippet Component="@typeof(IconsBasic)" Title="Basics">
-            <Description>
-                <p>Basic Icon</p>
-            </Description>
-        </CodeSnippet>
-
-        <CodeSnippet Component="@typeof(IconsColorSize)" Title="Settings">
-            <Description>
-                <p>Set size and color for each icon</p>
-            </Description>
-        </CodeSnippet>
-
-        <CodeSnippet Component="@typeof(IconsCSS)" Title="CSS">
-            <Description>
-                <p>Use css for icons</p>
-            </Description>
-        </CodeSnippet>
-
-        <CodeSnippet Component="@typeof(IconsAnimation)" Title="Animations">
-            <Description>
-                <p>Animations for icons</p>
-            </Description>
-        </CodeSnippet>
+            <div>
+                All icons come from the Tabler Icons set and are MIT-licensed
+                <a href="https://tabler-icons.io" target="_blank" rel="noopener">tabler-icons.io</a>
+                <Icon class="align-text-top" Size="16" IconType="@TablerIcons.Heart" TextColor="TablerColor.Red"
+                      Filled="true"/>
+            </div>
+        </Description>
+        <ChildContent>
 
 
-        <CodeSnippet Component="@typeof(IconsList)" Title="Icons list"/>
+            <CodeSnippet Component="@typeof(IconsBasic)" Title="Basics">
+                <Description>
+                    <p>Basic Icon</p>
+                </Description>
+            </CodeSnippet>
 
+            <CodeSnippet Component="@typeof(IconsColorSize)" Title="Settings">
+                <Description>
+                    <p>Set size and color for each icon</p>
+                </Description>
+            </CodeSnippet>
 
+            <CodeSnippet Component="@typeof(IconsCSS)" Title="CSS">
+                <Description>
+                    <p>Use css for icons</p>
+                </Description>
+            </CodeSnippet>
+
+            <CodeSnippet Component="@typeof(IconsAnimation)" Title="Animations">
+                <Description>
+                    <p>Animations for icons</p>
+                </Description>
+            </CodeSnippet>
+            
+            <CodeSnippet Component="@typeof(IconsList)" Title="Icons list"/>
+
+        </ChildContent>
     </DocsExample>
 </Page>
 


### PR DESCRIPTION
## What

Fixes #235 — migrates docs demo pages to the `DocsExample` `Description` / `ChildContent` slots and gives `DocsExample` a flatter, consistent layout.

## Changes

- **`DocsExample.razor`**: render an optional italic `Description` (`fst-italic fs-5`) above the cascading `ChildContent`; drop the `Card`/`CardBody` wrapper; minor markup tidy-up of the header/Component API button.
- **Demo pages** migrated to `<Description>` + `<ChildContent>` slots instead of inline markup:
  - Alerts
  - Icons
  - ClickOutside helper
  - ResizeObserver helper

## Scope

Docs site only (`docs/Tabler.Docs`); no library/component API change.

## Verification

`Tabler.Docs` builds with 0 errors (only the pre-existing `BL0007` warning).
